### PR TITLE
Allow to use the GUI when only IPython.html is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ or, alternatively, you can run them on your local computer by typing:
 
 `ipython notebook tutorials/`
 
+NB: For [NERSC](http://www.nersc.gov/) users, if you have installed
+the openPMD-viewer on a NERSC machine, you can run the tutorials on a
+remote machine by logging in at
+[https://ipython.nersc.gov](https://ipython.nersc.gov), and by
+navigating to your personal copy of the directory `openPMD-viewer/tutorials`.
+
 ## Contributing to the openPMD-viewer
 
 We welcome contributions to the code! Please read [this page](https://github.com/openPMD/openPMD-viewer/blob/master/CONTRIBUTING.md) for

--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -4,7 +4,13 @@ This file is part of the OpenPMD viewer
 It defines an interactive interface for the viewer,
 based on the IPython notebook functionalities
 """
-from ipywidgets import widgets
+try:
+    from ipywidgets import widgets
+except ImportError:
+    # If ipywidgets is not available, use the deprecated package
+    # IPython.html.widgets, so that the GUI still works
+    from IPython.html import widgets
+
 from IPython.display import display, clear_output
 import math
 import matplotlib

--- a/tutorials/3_Introduction-to-the-GUI.ipynb
+++ b/tutorials/3_Introduction-to-the-GUI.ipynb
@@ -46,7 +46,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In addition, we choose here to open pop-up windows for the plots."
+    "In addition, we choose here to incorporate the plots inside the notebook."
    ]
   },
   {
@@ -65,7 +65,7 @@
     }
    ],
    "source": [
-    "%matplotlib"
+    "%matplotlib inline"
    ]
   },
   {


### PR DESCRIPTION
When ipywidgets is not installed but IPython.html is installed, we should still allow the users to use the GUI. Although IPython.html is deprecated, it does contain the functionalities which are required for this GUI.