### PR TITLE
Modifications of the LPA diagnotics

### DIFF
--- a/opmd_viewer/__init__.py
+++ b/opmd_viewer/__init__.py
@@ -1,3 +1,3 @@
 # Make the OpenPMDTimeSeries object accessible from outside the package
-from .openpmd_timeseries import OpenPMDTimeSeries
-__all__ = ['OpenPMDTimeSeries']
+from .openpmd_timeseries import OpenPMDTimeSeries, FieldMetaInformation
+__all__ = ['OpenPMDTimeSeries', 'FieldMetaInformation']

--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -1,8 +1,6 @@
 # Class that inherits from OpenPMDTimeSeries, and implements
 # some standard diagnostics (emittance, etc.)
-from opmd_viewer import OpenPMDTimeSeries
-from opmd_viewer.openpmd_timeseries.data_reader.field_metainfo import (
-    FieldMetaInformation )
+from opmd_viewer import OpenPMDTimeSeries, FieldMetaInformation
 import numpy as np
 import scipy.constants as const
 
@@ -424,8 +422,8 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         frq = np.fft.fftfreq(field1d.size, z_length /
                              field1d.size * 1 / const.c) * 2 * np.pi
         # Calculate the mean of the frequencies
-        avg = np.average(frq[:frq.size/2]), weights=np.abs(
-                      fft_field[:frq.size/2])))
+        avg = np.average(frq[:frq.size/2], weights=np.abs(
+                      fft_field[:frq.size/2]))
         return( avg )
 
     def get_a0( self, t=None, iteration=None, pol=None ):

--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -376,7 +376,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
 
     def get_mean_frequency( self, t=None, iteration=None, pol=None, m='all'):
         """
-        Calculate the rms angular frequency of a laser pulse.
+        Calculate the mean angular frequency of a laser pulse.
 
         Parameters
         ----------
@@ -399,7 +399,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
 
         Returns
         -------
-        A float with rms angular frequency
+        A float with mean angular frequency
         """
         # Check if polarization has been entered
         if pol not in ['x', 'y']:
@@ -423,10 +423,10 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         # Corresponding angular frequency
         frq = np.fft.fftfreq(field1d.size, z_length /
                              field1d.size * 1 / const.c) * 2 * np.pi
-        # Calculate the RMS of the frequencies
-        rms = np.sqrt(np.average(frq[:frq.size/2]**2, weights=np.abs(
+        # Calculate the mean of the frequencies
+        avg = np.average(frq[:frq.size/2]), weights=np.abs(
                       fft_field[:frq.size/2])))
-        return( rms )
+        return( avg )
 
     def get_a0( self, t=None, iteration=None, pol=None ):
         """

--- a/opmd_viewer/openpmd_timeseries/__init__.py
+++ b/opmd_viewer/openpmd_timeseries/__init__.py
@@ -1,3 +1,4 @@
 # Make the OpenPMDTimeSeries accessible from outside the file main
 from .main import OpenPMDTimeSeries
-__all__ = ['OpenPMDTimeSeries']
+from .data_reader.field_metainfo import FieldMetaInformation
+__all__ = ['OpenPMDTimeSeries', 'FieldMetaInformation']

--- a/opmd_viewer/openpmd_timeseries/data_reader/field_metainfo.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/field_metainfo.py
@@ -85,3 +85,29 @@ class FieldMetaInformation(object):
 
         # Finalize imshow_extent by converting it from list to array
         self.imshow_extent = np.array(self.imshow_extent)
+
+    def restrict_to_1Daxis( axis ):
+        """
+        Suppresses the information that correspond to other axes than `axis`
+
+        Parameters
+        ----------
+        axis: string
+            The axis to keep
+            This has to be one of the keys of the self.axes dictionary
+        """
+        # Check if axis is a valid key
+        if (axis in self.axes)==False:
+            raise ValueError('`axis` is not one of the coordinates '
+                             'that are present in this object.')
+
+        # Loop through the coordinates and suppress them
+        for obsolete_axis in self.axes:
+            if obsolete_axis != axis:
+                delattr( self, obsolete_axis )
+                delattr( self, obsolete_axis+'min' )
+                delattr( self, obsolete_axis+'max' )
+
+        # Suppress imshow_extent and replace the dictionary
+        delattr( self, 'imshow_extent' )
+        self.axes = { 0:axis }

--- a/opmd_viewer/openpmd_timeseries/data_reader/field_metainfo.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/field_metainfo.py
@@ -86,7 +86,7 @@ class FieldMetaInformation(object):
         # Finalize imshow_extent by converting it from list to array
         self.imshow_extent = np.array(self.imshow_extent)
 
-    def restrict_to_1Daxis( axis ):
+    def restrict_to_1Daxis( self, axis ):
         """
         Suppresses the information that correspond to other axes than `axis`
 
@@ -97,12 +97,12 @@ class FieldMetaInformation(object):
             This has to be one of the keys of the self.axes dictionary
         """
         # Check if axis is a valid key
-        if (axis in self.axes)==False:
+        if (axis in self.axes.values()) is False:
             raise ValueError('`axis` is not one of the coordinates '
                              'that are present in this object.')
 
         # Loop through the coordinates and suppress them
-        for obsolete_axis in self.axes:
+        for obsolete_axis in self.axes.values():
             if obsolete_axis != axis:
                 delattr( self, obsolete_axis )
                 delattr( self, obsolete_axis+'min' )


### PR DESCRIPTION
I did a couple of modifications on the LPA diagnostics:

- Simplify the import of FieldMetaInformation by bringing it at the `opmd_viewer` level

- Added a method of FieldMetaInformation to restrict the data to 1D

- Modified the `get_mean_frequency` function:
Instead of taking the RMS value of the frequency, I took the frequency for which the spectrum is maximal. This is because, in testing the function on simulation, I found that even a small amount of noise at high frequency could have a large impact on the RMS, and thus shift significantly the value from the expected one. Searching for the frequency of the maximum avoids this. However, I agree that taking the frequency of the maximum also has many problem, and thus I not entirely decided on that. It'd be good to have your opinion on this.

- Modified the `wigner_transform` function. I mainly changed the name of the function and the variables, because the operation that is performed is actually not - mathematically speaking - a wigner transform. I also modified some parts of the function in an attempt to simplify it a bit, but please feel free to comment on those change below if you don't agree or would like to see modifications.

Thanks,