### PR TITLE
Fixed omega axis increment in get_spectrogram

### DIFF
--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -634,7 +634,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         maxi, maxj = np.unravel_index(spectrogram.argmax(), spectrogram.shape)
         tmin = -(T - T / spectrogram.shape[1] * maxj)
         info = FieldMetaInformation( {0:'omega', 1:'t'}, spectrogram.shape,
-                    grid_spacing=( np.pi/T, dt/2. ), grid_unitSI=1,
+                    grid_spacing=( 2*np.pi/T, dt/2. ), grid_unitSI=1,
                     global_offset=(0, tmin), position=(0, 0))
 
         # Plot the result if needed


### PR DESCRIPTION
I found a small bug in `get_spectrogram` : The omega increment should be 2*Pi/T