### PR TITLE
Adapt viewer to STANDARD (backward compatible)

### DIFF
--- a/opmd_viewer/openpmd_timeseries/data_reader/field_reader.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/field_reader.py
@@ -6,7 +6,7 @@ It defines functions that can read the fields from an HDF5 file.
 import os
 import h5py
 import numpy as np
-from .utilities import slice_dict, get_shape, get_data
+from .utilities import slice_dict, get_shape, get_data, get_bpath
 from .field_metainfo import FieldMetaInformation
 
 def read_field_2d( filename, field_path ):
@@ -227,7 +227,7 @@ def find_dataset( dfile, field_path ):
     - an h5py.Dataset object
     """
     # Find the meshes path
-    base_path = dfile.attrs["basePath"].decode()
+    base_path = get_bpath( dfile )
     relative_meshes_path = dfile.attrs["meshesPath"].decode()
 
     # Get the proper dataset

--- a/opmd_viewer/openpmd_timeseries/data_reader/params_reader.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/params_reader.py
@@ -5,7 +5,7 @@ It defines a function that can read standard parameters from an openPMD file.
 """
 import os
 import h5py
-from .utilities import is_scalar_record, get_shape
+from .utilities import is_scalar_record, get_shape, get_bpath
 
 def read_openPMD_params( filename ):
     """
@@ -34,7 +34,7 @@ def read_openPMD_params( filename ):
     params['extension'] = f.attrs['openPMDextension']
 
     # Find the base path object, and extract the time
-    bpath = f[ f.attrs["basePath"] ]
+    bpath = f[ get_bpath(f) ]
     t = bpath.attrs["time"] * bpath.attrs["timeUnitSI"]
 
     # Find out whether fields are present and extract their geometry
@@ -88,6 +88,9 @@ def read_openPMD_params( filename ):
         ptcl_quantities = []
         # Go through all the particle quantities
         for quantity_name in first_species.keys():
+            # Skip the particlePatches, which are not used here.
+            if quantity_name == 'particlePatches':
+                continue            
             quantity = first_species[quantity_name]
             if is_scalar_record( quantity ):
                 # Add the name of the scalar record

--- a/opmd_viewer/openpmd_timeseries/data_reader/particle_reader.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/particle_reader.py
@@ -6,7 +6,7 @@ It defines a function that reads particle data from an openPMD file
 import os
 import h5py
 from scipy import constants
-from .utilities import get_data
+from .utilities import get_data, get_bpath
 
 def read_particle( filename, species, quantity ) :
     """
@@ -42,7 +42,7 @@ def read_particle( filename, species, quantity ) :
 
     # Open the HDF5 file
     dfile = h5py.File( filename, 'r' )
-    base_path =  dfile.attrs['basePath'].decode()
+    base_path =  get_bpath( dfile )
     particles_path = dfile.attrs['particlesPath'].decode()
 
     # Find the right dataset

--- a/opmd_viewer/openpmd_timeseries/data_reader/utilities.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/utilities.py
@@ -11,6 +11,21 @@ import numpy as np
 slice_dict = { 'x':0, 'y':1, 'z':2 }
 
 
+def get_bpath( f ):
+    """
+    Return a string that corresponds to the base path of the data.
+
+    NB: For openPMD 1.0.0, the basePath is always of the form
+    '/data/%T' where %T is replaced by the actual iteration which
+    is present in the file. 
+    
+    Parameters:
+    -----------
+    f: am h5py.File object
+    """
+    iteration = f['/data'].keys()[0]
+    return( '/data/%s' %iteration )
+
 def is_scalar_record( record ):
     """
     Determine whether a record is a scalar record or a vector record


### PR DESCRIPTION
The openPMD STANDARD will soon be publicly released. Therefore, I had another look at it and found that the viewer was overlooking some aspects:

-   The possible existence of particlePatches: this commits explicitly tells the algorithm to ignore the particlePatches
-   The actual form of the basePath (the viewer assumed a string of the from '/data/0/' whereas the standard specifies that the string should be of the form '/data/%T')

This pull request corrects those problems. These changes are backward compatible, meaning that this will still work with current output of Warp and FBPIC.
