### PR TITLE
Close #17: Add a widget in the GUI to select in which figure to plot the results 

### DIFF
--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -212,7 +212,7 @@ class InteractiveViewer(object):
             # ----------------
             # Figure number
             fld_figure_button = widgets.IntText( description='Figure ',
-                                        value=0, width=50 )
+                                        value=0, width=50)
             # Range of values
             fld_range_button = widgets.FloatRangeSlider(
                 min=-10, max=10, width=220 )
@@ -254,8 +254,8 @@ class InteractiveViewer(object):
             # Plotting options container
             container_fld_plots = widgets.VBox( width=260,
                 children=[ fld_figure_button, fld_range_button,
-            widgets.HBox( children=[ fld_magnitude_button, fld_use_button] ),
-            fld_color_button ] )
+            widgets.HBox( children=[ fld_magnitude_button, fld_use_button],
+                          height=50 ), fld_color_button ] )
             # Accordion for the field widgets
             accord1 = widgets.Accordion(
                 children=[container_fields, container_fld_plots] )
@@ -339,8 +339,8 @@ class InteractiveViewer(object):
             # Plotting options container
             container_ptcl_plots = widgets.VBox( width=310,
             children=[ ptcl_figure_button, ptcl_bins_button, ptcl_range_button,
-            widgets.HBox(children=[ ptcl_magnitude_button, ptcl_use_button] ),
-            ptcl_color_button ])
+            widgets.HBox(children=[ ptcl_magnitude_button, ptcl_use_button],
+                         height=50), ptcl_color_button ])
             # Accordion for the field widgets
             accord2 = widgets.Accordion(
             children=[container_ptcl_quantities, container_ptcl_select,

--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -21,20 +21,17 @@ class InteractiveViewer(object):
     def __init__(self) :
         pass
 
-    def slider(self, figsize=(10,10), ifig_f=0, ifig_p=1, **kw) :
+    def slider(self, figsize=(10,10), **kw) :
         """
         Navigate the simulation using a slider
 
         Parameters :
         ------------
-        ifig_f : int
-           Number of the figure where to plot the fields
+        figsize: tuple
+            Size of the figures
 
-        ifig_g : int
-           Number of the figure where to plot the particles
-
-        kw : dict
-           Extra arguments to pass to matplotlib's imshow
+        kw: dict
+            Extra arguments to pass to matplotlib's imshow
         """
 
         # -----------------------
@@ -51,7 +48,7 @@ class InteractiveViewer(object):
                     do_refresh = True
             # Do the refresh
             if do_refresh == True :
-                plt.figure(ifig_f, figsize=figsize)
+                plt.figure(fld_figure_button.value, figsize=figsize)
                 plt.clf()
 
                 # When working in inline mode, in an ipython notebook,
@@ -85,7 +82,7 @@ class InteractiveViewer(object):
                     do_refresh = True
             # Do the refresh
             if do_refresh == True :
-                plt.figure(ifig_p, figsize=figsize)
+                plt.figure(ptcl_figure_button.value, figsize=figsize)
                 plt.clf()
 
                 # When working in inline mode, in an ipython notebook,
@@ -213,6 +210,9 @@ class InteractiveViewer(object):
 
             # Plotting options
             # ----------------
+            # Figure number
+            fld_figure_button = widgets.IntText( description='Figure ',
+                                        value=0, width=50 )
             # Range of values
             fld_range_button = widgets.FloatRangeSlider(
                 min=-10, max=10, width=220 )
@@ -253,7 +253,7 @@ class InteractiveViewer(object):
                     slicing_dir_button, slicing_button ] )
             # Plotting options container
             container_fld_plots = widgets.VBox( width=260,
-                children=[ fld_range_button,
+                children=[ fld_figure_button, fld_range_button,
             widgets.HBox( children=[ fld_magnitude_button, fld_use_button] ),
             fld_color_button ] )
             # Accordion for the field widgets
@@ -297,6 +297,9 @@ class InteractiveViewer(object):
 
             # Plotting options
             # ----------------
+            # Figure number
+            ptcl_figure_button = widgets.IntText( description='Figure ',
+                                            value=1, width=50 )
             # Number of bins
             ptcl_bins_button = widgets.IntSlider( description='nbins:',
                             min=50, max=300, value=100, width=150 )
@@ -335,7 +338,7 @@ class InteractiveViewer(object):
             container_ptcl_select = ptcl_select_widget.to_container()
             # Plotting options container
             container_ptcl_plots = widgets.VBox( width=310,
-            children=[ ptcl_bins_button, ptcl_range_button,
+            children=[ ptcl_figure_button, ptcl_bins_button, ptcl_range_button,
             widgets.HBox(children=[ ptcl_magnitude_button, ptcl_use_button] ),
             ptcl_color_button ])
             # Accordion for the field widgets

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -227,13 +227,13 @@ class OpenPMDTimeSeries(parent_class) :
             # - In the case of only one quantity
             if len(data_list) == 1:
                 # Do the plotting
-                self.plotter.hist1d( data_list[0], w, var_list[0],
+                self.plotter.hist1d( data_list[0], w, var_list[0], species,
                                      self.current_i, nbins, **kw )
             # - In the case of two quantities
             elif len(data_list) == 2:
                 # Do the plotting
                 self.plotter.hist2d( data_list[0], data_list[1], w,
-                                     var_list[0], var_list[1],
+                                     var_list[0], var_list[1], species, 
                                      self.current_i, nbins, **kw )
         # Output
         if output :

--- a/opmd_viewer/openpmd_timeseries/plotter.py
+++ b/opmd_viewer/openpmd_timeseries/plotter.py
@@ -33,8 +33,8 @@ class Plotter(object):
         self.iterations = iterations
 
 
-    def hist1d( self, q1, w, quantity1, current_i, nbins, cmap='Blues',
-                vmin=None, vmax=None, **kw ):
+    def hist1d( self, q1, w, quantity1, species, current_i, nbins,
+                cmap='Blues', vmin=None, vmax=None, **kw ):
         """
         Plot a 1D histogram of the particle quantity q1
         Sets the proper labels
@@ -52,6 +52,9 @@ class Plotter(object):
         quantity1: string
             The name of the quantity to be plotted (for labeling purposes)
 
+        species: string
+            The name of the species from which the data is taken
+            
         current_i: int
             The index of this iteration, within the iterations list
 
@@ -68,11 +71,11 @@ class Plotter(object):
         # Do the plot
         plt.hist(q1, bins=nbins, weights=w, **kw )
         plt.xlabel(quantity1, fontsize=self.fontsize)
-        plt.title("t =  %.0f fs    (iteration %d)" \
-                %(time_fs, iteration), fontsize=self.fontsize )
+        plt.title("%s:   t =  %.0f fs    (iteration %d)" \
+                %(species, time_fs, iteration), fontsize=self.fontsize )
 
 
-    def hist2d( self, q1, q2, w, quantity1, quantity2, current_i,
+    def hist2d( self, q1, q2, w, quantity1, quantity2, species, current_i,
                 nbins, cmap='Blues', vmin=None, vmax=None, **kw ):
         """
         Plot a 2D histogram of the particle quantity q1
@@ -88,9 +91,12 @@ class Plotter(object):
             An array with one element per macroparticle, representing
             the number of real particles that correspond to each macroparticle
 
-        quantity1: string
+        quantity1, quantity2: strings
             The name of the quantity to be plotted (for labeling purposes)
 
+        species: string
+            The name of the species from which the data is taken
+            
         current_i: int
             The index of this iteration, within the iterations list
 
@@ -110,8 +116,8 @@ class Plotter(object):
         plt.colorbar()
         plt.xlabel(quantity1, fontsize=self.fontsize)
         plt.ylabel(quantity2, fontsize=self.fontsize)
-        plt.title("t =  %.1f fs   (iteration %d)"  \
-                %(time_fs, iteration ), fontsize=self.fontsize )
+        plt.title("%s:   t =  %.1f fs   (iteration %d)"  \
+                %(species, time_fs, iteration ), fontsize=self.fontsize )
 
 
     def show_field( self, F, info, slicing_dir, m,


### PR DESCRIPTION
NB: This pull request is useful when using the IPython notebook with the `%matplotlib` instruction (new figures pop up, out of the browser), not with the `%matplotlib inline` instruction (figures are contained inside the browser).

In that case, being able to select the figure on which to plot, at the GUI level, has 2 advantages:

- When using two sliders for two different simulations in the same IPython notebook, one can avoid that the two sliders update the same figures, and thus one can look at the two simulations simultaneously.

- Even when using only one slider, changing figure in the middle of your data exploration will freeze the previous figure and continue with the new figure. Thus you can compare different iterations / different fields with this trick.

I also made several esthetical changes (in particular, adding the name of the species to the plots).