### PR TITLE
Normalize the spectrum of the laser

### DIFF
--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -464,7 +464,8 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         # Get central field lineout
         field1d = field[field.shape[0]/2, :]
         # FFT of 1d data
-        fft_field = np.fft.fft(field1d)
+        dt = (info.z[1]-info.z[0])/const.c  # Integration step for the FFT
+        fft_field = np.fft.fft(field1d) * dt
         # Take half of the data (positive frequencies only)
         spectrum = abs( fft_field[ :len(fft_field)/2 ] )
         # Create a FieldMetaInformation object


### PR DESCRIPTION
This introduces a dt coefficient in the calculation of the spectrum
so that the spectrum really corresponds to the discretization of
![tmpremi](https://cloud.githubusercontent.com/assets/1353258/11091159/237e8014-8878-11e5-81b4-93415e576a6b.png)

Without the dt coefficient, the amplitude of the spectrum scales
linearly with the number of gridpoints along z, which is unwanted when comparing
spectra for two different resolution.