### PR TITLE
Add executable `openPMD_notebook`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ The routines of openPMD viewer can be used in two ways :
 - Use the **interactive GUI inside the IPython Notebook**, in order to interactively
 visualize the data.
 
-The notebooks in the folder `tutorials/` demonstrate how to use these
-routines. You can view these notebooks online
+#### Tutorials
+
+The notebooks in the folder `tutorials/` demonstrate how to use both
+the API and the interactive GUI. You can view these notebooks online
 [here](https://github.com/openPMD/openPMD-viewer/tree/master/tutorials),
 or, alternatively, you can run them on your local computer by typing:
 
@@ -56,6 +58,17 @@ NB: For [NERSC](http://www.nersc.gov/) users, you can run the tutorials on a
 remote machine by logging in at
 [https://ipython.nersc.gov](https://ipython.nersc.gov), and by
 navigating to your personal copy of the directory `openPMD-viewer/tutorials`.
+
+#### Notebook quick-starter
+
+If you wish to use the **interactive GUI**, the installation of `openPMD-viewer` provides
+a convenient executable which automatically
+**creates a new pre-filled notebook** and **opens it in a
+browser**. To use this executable, simply type in a regular terminal:
+
+`openPMD_notebook`
+
+(This executable is installed by default when running `python setup.py install`.)
 
 ## Contributing to the openPMD-viewer
 

--- a/opmd_viewer/notebook_starter/Template_notebook.ipynb
+++ b/opmd_viewer/notebook_starter/Template_notebook.ipynb
@@ -1,0 +1,74 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is a pre-filled notebook, for the visualization of openPMD files.\n",
+    "\n",
+    "- Modify the path in cell 2, so that it points to your data\n",
+    "- Click `Cell > Run all` in the above menu"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Import relevant packages and setup visualization\n",
+    "# NB: The default setup produces pop-up windows for the plots.\n",
+    "# To include the plots in the notebook, use `%matplotlib notebook`.\n",
+    "from opmd_viewer import OpenPMDTimeSeries\n",
+    "%matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Point to the folder containing the openPMD files\n",
+    "ts = OpenPMDTimeSeries('./diags/hdf5/')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Create the interactive GUI\n",
+    "ts.slider()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/opmd_viewer/notebook_starter/openPMD_notebook
+++ b/opmd_viewer/notebook_starter/openPMD_notebook
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+"""
+This executable script is part of the openPMD-viewer package.
+
+It automatically creates a new pre-filled IPython notebook
+in the local directory, and opens it in a browser.
+
+Usage: Simply type `openPMD_notebook` in a regular terminal
+"""
+import os
+from pkg_resources import resource_string
+
+# Use pkg_resources to retrieve the location and contents
+# of the pre-existing template notebook
+notebook_text = resource_string('opmd_viewer',
+                                'notebook_starter/Template_notebook.ipynb')
+
+# Create a new notebook in the local directory and copy
+# the contents of the pre-existing template
+with open('./openPMD-visualization.ipynb', 'w') as notebook_file:
+    notebook_file.write( notebook_text )
+
+# Launch the corresponding notebook
+os.system('ipython notebook openPMD-visualization.ipynb')

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(name='opmd_viewer',
       version='1.0',
@@ -9,7 +8,7 @@ setup(name='opmd_viewer',
       description='Visualization tools for OpenPMD files',
       url='git@bitbucket.org:berkeleylab/opmd_viewer.git',
       install_requires=['numpy', 'scipy', 'matplotlib', 'h5py'],
-      packages = ['opmd_viewer', 'opmd_viewer.openpmd_timeseries', 
-                  'opmd_viewer.openpmd_timeseries.data_reader', 
-                  'opmd_viewer.addons', 'opmd_viewer.addons/pic' ]
+      packages = find_packages('./'),
+      package_data = {'opmd_viewer':['notebook_starter/*.ipynb']},
+      scripts = ['opmd_viewer/notebook_starter/openPMD_notebook']
       )


### PR DESCRIPTION
For new users, it is not easy to remember what to write inside a new IPython notebook, in order to have the GUI working. 

Therefore, I included a small executable script that creates a pre-filled notebook and automatically opens it in a browser. Please see the README.md for documentation on that script.