### PR TITLE
Remove pointless print messages

### DIFF
--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -136,7 +136,6 @@ class InteractiveViewer(object):
             if self.current_i < len(self.t) - 1 :
                 self.current_t = self.t[self.current_i+1]
             else :
-                print("Reached last iteration.")
                 self.current_t = self.t[self.current_i]
             slider.value = self.current_t*1.e15
 
@@ -145,7 +144,6 @@ class InteractiveViewer(object):
             if self.current_t > 0 :
                 self.current_t = self.t[self.current_i-1]
             else :
-                print("Reached first iteration.")
                 self.current_t= self.t[self.current_i]
             slider.value = self.current_t*1.e15
 

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -415,10 +415,8 @@ class OpenPMDTimeSeries(parent_class) :
             # Make sur the time requested does not exceed the allowed bounds
             if t < self.tmin :
                 self.current_i = 0
-                print('Reached first iteration')
             elif t > self.tmax :
                 self.current_i = len(self.t) -1
-                print('Reached last iteration')
             # Find the last existing output
             else :
                 self.current_i = self.t[ self.t <= t ].argmax()


### PR DESCRIPTION
These messages indicated when the first and last iteration where reached,
but they seem pointless and actually clutter the notebook when using a slider.