### PR TITLE
.gitignore: *.egg files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.DS_Store
+*.egg
 build/
 dist/
 opmd_viewer.egg-info/


### PR DESCRIPTION
during build, there is always an
  `pytest_runner-<pyversion>-py<pyver>.egg`

file created in the root path. This line adds it to the ignored files (alongside the other build files).