### PR TITLE
openPMD Extensions: Implement Detection

### DIFF
--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -75,7 +75,7 @@ class OpenPMDTimeSeries(parent_class) :
         t, params0 = read_openPMD_params( self.h5_files[0] )
         self.t[0] = t
         self.avail_fields = params0['avail_fields']
-        self.extension = params0['extension']
+        self.extensions = params0['extensions']
         if self.avail_fields is not None:
             self.geometry = params0['geometry']
             self.avail_circ_modes = params0['avail_circ_modes']


### PR DESCRIPTION
This pull request implements the correct named detection of [openPMD extensions](https://github.com/openPMD/openPMD-standard/blob/1.0.0/STANDARD.md#hierarchy-of-the-data-file).

Since a file can implement several extensions at the same time, the extension is encoded as a [bitmask](https://en.wikipedia.org/wiki/Mask_%28computing%29). The user does not care about the bit mask but about a final list of extensions that are supported :)

### API Changes

- `OpenPMDTimeSeries.extension`
  - removed
  - (did contain the [bitmask](https://en.wikipedia.org/wiki/Mask_%28computing%29))
  - (not used in the code yet nor in examples)
- `OpenPMDTimeSeries.extensions`
  - added (plural!)
  - contains a list of named extensions
  - detection and name matching is done in `params_reader.py`
    for each file (same implementation level as version)

### Usage

A user can now query
```python
from opmd_viewer import OpenPMDTimeSeries

ts = OpenPMDTimeSeries('...')
print(ts.extensions)
# []
# ['ED-PIC']
# ['ED-PIC', 'An-other-fancy-extension']

if 'ED-PIC' in ts.extensions:
    print('I will now do PIC specific stuff!')
```