### PR TITLE
Record Component Detection: Per Species

### DIFF
--- a/opmd_viewer/openpmd_timeseries/data_reader/params_reader.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/params_reader.py
@@ -89,24 +89,24 @@ def read_openPMD_params( filename ):
             species = bpath[os.path.join(particle_path, species_name)]
             species_record_components[species_name] = []
 
-            # Go through all the particle quantities of this species
-            for quantity_name in species.keys():
+            # Go through all the particle records of this species
+            for record_name in species.keys():
                 # Skip the particlePatches, which are not used here.
-                if quantity_name == 'particlePatches':
+                if record_name == 'particlePatches':
                     continue
-                quantity = species[quantity_name]
-                if is_scalar_record( quantity ):
+                record = species[record_name]
+                if is_scalar_record( record ):
                     # Add the name of the scalar record
                     species_record_components[species_name]. \
-                        append( quantity_name )
+                        append( record_name )
                 else:
                     # Add each component of the vector record
-                    for coord in quantity.keys():
+                    for coord in record.keys():
                         species_record_components[species_name]. \
-                            append(os.path.join(quantity_name, coord))
-            # Simplify the name of some standard openPMD quantities
+                            append(os.path.join(record_name, coord))
+            # Simplify the name of some standard openPMD records
             species_record_components[species_name] = \
-                simplify_quantities( species_record_components[species_name] )
+                simplify_record( species_record_components[species_name] )
         params['avail_species_record_components'] = species_record_components
         # deprecated
         first_species_name = next(iter(params['avail_species']))
@@ -124,47 +124,47 @@ def read_openPMD_params( filename ):
     return( t, params )
 
 
-def simplify_quantities( quantities ):
+def simplify_record( record_comps ) :
     """
-    Replace the names of some standard quantities by shorter names
+    Replace the names of some standard record by shorter names
 
     Parameter
     ---------
-    quantities: a list of strings
-        A list of available particle quantities
+    record_comps: a list of strings
+        A list of available particle record components
     
     Returns
     -------
     A list with shorter names, where applicable
     """
     # Replace the names of the positions
-    if ('position/x' in quantities) and ('positionOffset/x' in quantities):
-        quantities.remove('position/x')
-        quantities.remove('positionOffset/x')
-        quantities.append('x')
-    if ('position/y' in quantities) and ('positionOffset/y' in quantities):
-        quantities.remove('position/y')
-        quantities.remove('positionOffset/y')
-        quantities.append('y')
-    if ('position/z' in quantities) and ('positionOffset/z' in quantities):
-        quantities.remove('position/z')
-        quantities.remove('positionOffset/z')
-        quantities.append('z')
+    if ('position/x' in record_comps) and ('positionOffset/x' in record_comps):
+        record_comps.remove('position/x')
+        record_comps.remove('positionOffset/x')
+        record_comps.append('x')
+    if ('position/y' in record_comps) and ('positionOffset/y' in record_comps):
+        record_comps.remove('position/y')
+        record_comps.remove('positionOffset/y')
+        record_comps.append('y')
+    if ('position/z' in record_comps) and ('positionOffset/z' in record_comps):
+        record_comps.remove('position/z')
+        record_comps.remove('positionOffset/z')
+        record_comps.append('z')
 
     # Replace the names of the momenta
-    if 'momentum/x' in quantities:
-        quantities.remove('momentum/x')
-        quantities.append('ux')
-    if 'momentum/y' in quantities:
-        quantities.remove('momentum/y')
-        quantities.append('uy')
-    if 'momentum/z' in quantities:                
-        quantities.remove('momentum/z')
-        quantities.append('uz')
+    if 'momentum/x' in record_comps:
+        record_comps.remove('momentum/x')
+        record_comps.append('ux')
+    if 'momentum/y' in record_comps:
+        record_comps.remove('momentum/y')
+        record_comps.append('uy')
+    if 'momentum/z' in record_comps:
+        record_comps.remove('momentum/z')
+        record_comps.append('uz')
 
     # Replace the name for 'weights'
-    if 'weighting' in quantities:
-        quantities.remove('weighting')
-        quantities.append('w')
+    if 'weighting' in record_comps:
+        record_comps.remove('weighting')
+        record_comps.append('w')
 
-    return(quantities)
+    return(record_comps)

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -80,8 +80,10 @@ class OpenPMDTimeSeries(parent_class) :
             self.geometry = params0['geometry']
             self.avail_circ_modes = params0['avail_circ_modes']
         self.avail_species = params0['avail_species']
-        if self.avail_species is not None:
-            self.avail_ptcl_quantities = params0['avail_ptcl_quantities']
+        self.avail_species_record_components = \
+            params0['avail_species_record_components']
+        # deprecated
+        self.avail_ptcl_quantities = params0['avail_ptcl_quantities']
 
         # - Check that the other files have the same parameters
         for k in range( 1, N_files ):
@@ -176,16 +178,16 @@ class OpenPMDTimeSeries(parent_class) :
             valid_var_list = False
         else:
             for quantity in var_list:
-                if (quantity in self.avail_ptcl_quantities) == False:
+                if (quantity in self.avail_species_record_components[species]) == False:
                     valid_var_list = False
         if valid_var_list == False:
-            quantity_list = '\n - '.join( self.avail_ptcl_quantities )
+            quantity_list = '\n - '.join( self.avail_species_record_components[species] )
             raise OpenPMDException(
                 "The argument `var_list` is missing or erroneous.\n"
-                "It should be a list of strings representing particle "
-                "quantities.\n The available quantities are: "
+                "It should be a list of strings representing species record "
+                "components.\n The available quantities for species '%s' are:"
                 "\n - %s\nPlease set the argument `var_list` "
-                "accordingly." %quantity_list )
+                "accordingly." % species % quantity_list )
 
         # Check the selection quantities
         if select is not None:
@@ -194,10 +196,10 @@ class OpenPMDTimeSeries(parent_class) :
                 valid_select_list = False
             else:
                 for quantity in select.keys():
-                    if (quantity in self.avail_ptcl_quantities) == False:
+                    if (quantity in self.avail_species_record_components[species]) == False:
                         valid_select_list = False
             if valid_select_list == False:
-                quantity_list = '\n - '.join( self.avail_ptcl_quantities )
+                quantity_list = '\n - '.join( self.avail_species_record_components[species] )
                 raise OpenPMDException(
                     "The argument `select` is erroneous.\n"
                     "It should be a dictionary whose keys represent particle "
@@ -223,7 +225,7 @@ class OpenPMDTimeSeries(parent_class) :
         if plot :
 
             # Extract the weights, if they are available
-            if 'w' in self.avail_ptcl_quantities:
+            if 'w' in self.avail_species_record_components[species]:
                 w = read_particle( filename, species, 'w' )
                 if select is not None:
                     w, = apply_selection( [w], select, species, filename )


### PR DESCRIPTION
It is a too strict assumption that all species must be identical in their records. This commit adds a `species_record_components` attribute created by `read_openPMD_params` that is a dictionary for each species containing the usual list of record components.

I unified the naming a bit since it is useful if we stay with the naming in the standard ("record component") and not introduce new namings (such as "particle quantity").

### Previous Implementation

Since the old attribute `avail_ptcl_quantities` is
- assuming all species are identical
- using an undefined naming

let us internally "deprecate" it for removal in the future. (Nevertheless, for now it still works as before.) Unfortunately, I found no easy way to throw a warning on usage since one would need to wrap the `__getattr[ibute]__` member for that with a base class.

### Change in API

In case no species are found, the old member `avail_ptcl_quantities` (and the new member `species_record_components`) are still *defined* and set to `None` instead of letting them undefined. The simple reason for that is, that catching a "member not found" is more expensive and more verbose then simply iterating over a `None` (empty) but *existing* member.

### Further Work

For the `interactive.py` class we should add an event handling that is refreshing the `record components` of particles as soon as a user selected a new `species`.

This can be done in an independent PR into `dev`.