### PR TITLE
Updated the notebook starter

### DIFF
--- a/opmd_viewer/notebook_starter/openPMD_notebook
+++ b/opmd_viewer/notebook_starter/openPMD_notebook
@@ -21,4 +21,4 @@ with open('./openPMD-visualization.ipynb', 'w') as notebook_file:
     notebook_file.write( notebook_text )
 
 # Launch the corresponding notebook
-os.system('ipython notebook openPMD-visualization.ipynb')
+os.system('jupyter notebook openPMD-visualization.ipynb')


### PR DESCRIPTION
The command 'ipython notebook' is now deprecated, and is replaced by 'jupyter notebook'