### PR TITLE
`get_particle`: Speed Up Read

### DIFF
--- a/opmd_viewer/openpmd_timeseries/data_reader/particle_reader.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/particle_reader.py
@@ -1,63 +1,62 @@
 """
 This file is part of the OpenPMD viewer.
 
-It defines a function that reads particle data from an openPMD file
+It defines a function that reads a species record component (data & meta)
+from an openPMD file
 """
 import os
-import h5py
 from scipy import constants
 from .utilities import get_data, get_bpath
 
-def read_particle( filename, species, quantity ) :
+def read_species_data( file_handle, species, record_comp ) :
     """
-    Extract a given particle quantity
+    Extract a given species' record_comp
     
     In the case of positions, the result is returned in microns
     
     Parameters
     ----------
-    filename : string
-        The name of the file from which to extract data
+    file_handle : h5py.File object
+        The HDF5 file from which to extract data
     
     species : string
         The name of the species to extract (in the OpenPMD file)
 
-    quantity : string
-        The quantity to extract
+    record_comp : string
+        The record component to extract
         Either 'x', 'y', 'z', 'ux', 'uy', 'uz', or 'w'
 
     """
-    # Translate the quantity to the OpenPMD format
-    dict_quantity = { 'x' : 'position/x',
-                      'y' : 'position/y',
-                      'z' : 'position/z',
-                      'ux' : 'momentum/x',
-                      'uy' : 'momentum/y',
-                      'uz' : 'momentum/z',
-                      'w' : 'weighting'}
-    if quantity in dict_quantity:
-        opmd_quantity = dict_quantity[quantity]
+    # Translate the record component to the OpenPMD format
+    dict_record_comp = { 'x' : 'position/x',
+                         'y' : 'position/y',
+                         'z' : 'position/z',
+                         'ux' : 'momentum/x',
+                         'uy' : 'momentum/y',
+                         'uz' : 'momentum/z',
+                         'w' : 'weighting'}
+    if record_comp in dict_record_comp:
+        opmd_record_comp = dict_record_comp[record_comp]
     else:
-        opmd_quantity = quantity
+        opmd_record_comp = record_comp
 
     # Open the HDF5 file
-    dfile = h5py.File( filename, 'r' )
-    base_path =  get_bpath( dfile )
-    particles_path = dfile.attrs['particlesPath'].decode()
+    base_path =  get_bpath( file_handle )
+    particles_path = file_handle.attrs['particlesPath'].decode()
 
     # Find the right dataset
-    species_grp =  dfile[ os.path.join( base_path, particles_path, species ) ]
-    data = get_data( species_grp[ opmd_quantity ] )
+    species_grp =  file_handle[ os.path.join( base_path, particles_path, species ) ]
+    data = get_data( species_grp[ opmd_record_comp ] )
 
     # - Return positions in microns, with an offset
-    if quantity in ['x', 'y', 'z']:
-        offset = get_data( species_grp[ 'positionOffset/%s' %quantity ] )
+    if record_comp in ['x', 'y', 'z']:
+        offset = get_data( species_grp[ 'positionOffset/%s' %record_comp ] )
         data = 1.e6 * (data + offset)
     # - Return momentum in normalized units
-    elif quantity in ['ux', 'uy', 'uz' ]: 
+    elif record_comp in ['ux', 'uy', 'uz' ]:
         norm_factor = 1./( get_data( species_grp['mass'] ) * constants.c )
         data = data * norm_factor
 
-    # Close the HDF5 file and return the data
-    dfile.close()
+    # Return the data
     return( data )
+


### PR DESCRIPTION
This commits speeds up reads in `get_particle` by keeping the file opened between the calls to `get_species_data`.

File opening-closing is an operation with high latencies and should therefore be minimized.

The internal `get_particle` interface has been renamed to openPMD namings. Instead of the `filename` a `file_handle` with an already opened (*read*) `h5py.File` object is passed.