### PR TITLE
Travis: Add flake8 Test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,15 @@ install:
   - conda install --yes python=$TRAVIS_PYTHON_VERSION --file requirements.txt
   - conda install --yes python=$TRAVIS_PYTHON_VERSION jupyter
   - conda install --yes python=$TRAVIS_PYTHON_VERSION pyflakes
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION flake8
   - python setup.py install
+
 before_script :
+  # static code analysis
+  #   pyflakes: mainly warnings, unused code, etc.
   - python -m pyflakes .
+  #   flake8: style only, enforce PEP 8
+  - python -m flake8 --ignore=E201,E202,E122,E127,E128,E131 .
+
 script: 
   - "python setup.py test"


### PR DESCRIPTION
Close #68: flake8 can be used to enforce PEP8.

I excluded a lot of issues for now to keep the burden a bit lower. But if someone wants to fix them feel free to go :)