### PR TITLE
Close #56 License Headers

### DIFF
--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -1,3 +1,13 @@
+"""
+This file is part of the openPMD viewer.
+
+This file contains diagnostics relevant for laser-plasma acceleration
+
+__authors__ = "Soeren Jalas, Remi Lehe"
+__copyright__ = "Copyright 2015-2016, openPMD viewer contributors"
+__license__ = "3-Clause-BSD-LBNL"
+"""
+
 # Class that inherits from OpenPMDTimeSeries, and implements
 # some standard diagnostics (emittance, etc.)
 from opmd_viewer import OpenPMDTimeSeries, FieldMetaInformation

--- a/opmd_viewer/openpmd_timeseries/data_reader/field_metainfo.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/field_metainfo.py
@@ -1,10 +1,15 @@
 """
-This file is part of the OpenPMD viewer.
+This file is part of the openPMD viewer.
 
 It defines the main FieldMetaInformation class, which
 is returned by `get_field` along with the array of field values,
 and gathers information collected from the openPMD file.
+
+__authors__ = "Remi Lehe"
+__copyright__ = "Copyright 2015-2016, openPMD viewer contributors"
+__license__ = "3-Clause-BSD-LBNL"
 """
+
 import numpy as np
 
 

--- a/opmd_viewer/openpmd_timeseries/data_reader/field_reader.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/field_reader.py
@@ -2,7 +2,12 @@
 This file is part of the openPMD viewer.
 
 It defines functions that can read the fields from an HDF5 file.
+
+__authors__ = "Remi Lehe"
+__copyright__ = "Copyright 2015-2016, openPMD viewer contributors"
+__license__ = "3-Clause-BSD-LBNL"
 """
+
 import os
 import h5py
 import numpy as np

--- a/opmd_viewer/openpmd_timeseries/data_reader/params_reader.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/params_reader.py
@@ -2,7 +2,12 @@
 This file is part of the openPMD viewer.
 
 It defines a function that can read standard parameters from an openPMD file.
+
+__authors__ = "Remi Lehe, Axel Huebl"
+__copyright__ = "Copyright 2015-2016, openPMD viewer contributors"
+__license__ = "3-Clause-BSD-LBNL"
 """
+
 import os
 import h5py
 import numpy as np

--- a/opmd_viewer/openpmd_timeseries/data_reader/particle_reader.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/particle_reader.py
@@ -1,9 +1,14 @@
 """
-This file is part of the OpenPMD viewer.
+This file is part of the openPMD viewer.
 
 It defines a function that reads a species record component (data & meta)
 from an openPMD file
+
+__authors__ = "Remi Lehe, Axel Huebl"
+__copyright__ = "Copyright 2015-2016, openPMD viewer contributors"
+__license__ = "3-Clause-BSD-LBNL"
 """
+
 import os
 from scipy import constants
 from .utilities import get_data, get_bpath

--- a/opmd_viewer/openpmd_timeseries/data_reader/utilities.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/utilities.py
@@ -1,11 +1,17 @@
 """
-This file is part of the OpenPMD viewer.
+This file is part of the openPMD viewer.
 
 It defines a set of helper data and functions which
 are used by the other files.
+
+__authors__ = "Remi Lehe, Axel Huebl"
+__copyright__ = "Copyright 2015-2016, openPMD viewer contributors"
+__license__ = "3-Clause-BSD-LBNL"
 """
+
 import h5py
 import numpy as np
+
 
 # General dictionaries
 slice_dict = {'x': 0, 'y': 1, 'z': 2}

--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -1,9 +1,14 @@
 """
-This file is part of the OpenPMD viewer
+This file is part of the openPMD viewer.
 
 It defines an interactive interface for the viewer,
 based on the IPython notebook functionalities
+
+__authors__ = "Remi Lehe, Axel Huebl"
+__copyright__ = "Copyright 2015-2016, openPMD viewer contributors"
+__license__ = "3-Clause-BSD-LBNL"
 """
+
 try:
     from ipywidgets import widgets
 except ImportError:

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -1,8 +1,13 @@
 """
-This file is part of the OpenPMD viewer.
+This file is part of the openPMD viewer.
 
 It defines the main OpenPMDTimeSeries class.
+
+__authors__ = "Remi Lehe, Axel Huebl"
+__copyright__ = "Copyright 2015-2016, openPMD viewer contributors"
+__license__ = "3-Clause-BSD-LBNL"
 """
+
 import os
 import re
 import numpy as np
@@ -12,6 +17,7 @@ from .data_reader.params_reader import read_openPMD_params
 from .data_reader.particle_reader import read_species_data
 from .data_reader.field_reader import read_field_2d, \
     read_field_circ, read_field_3d
+
 
 # Check wether the interactive interface can be loaded
 try:

--- a/opmd_viewer/openpmd_timeseries/plotter.py
+++ b/opmd_viewer/openpmd_timeseries/plotter.py
@@ -1,9 +1,14 @@
 """
-This file is part of the OpenPMD viewer.
+This file is part of the openPMD viewer.
 
 It defines a set of methods which are useful for plotting
 (and labeling the plots).
+
+__authors__ = "Remi Lehe"
+__copyright__ = "Copyright 2015-2016, openPMD viewer contributors"
+__license__ = "3-Clause-BSD-LBNL"
 """
+
 import matplotlib.pyplot as plt
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ install_requires.append('wget')
 # Main setup command
 setup(name='opmd_viewer',
       version='1.0',
-      author='Remi Lehe',
-      author_email='remi.lehe@lbl.gov',
+      maintainer='Remi Lehe',
+      maintainer_email='remi.lehe@lbl.gov',
       description='Visualization tools for OpenPMD files',
       url='git@bitbucket.org:berkeleylab/opmd_viewer.git',
       packages=find_packages('./'),

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -1,15 +1,20 @@
 """
-This test file is part of the openPMD-viewer.
+This test file is part of the openPMD viewer.
 
 It makes sure that the tutorial notebooks run without error.
 
 Usage:
-This file is meant to be run from the root directory of openPMD-viewer,
+This file is meant to be run from the root directory of openPMD viewer,
 by any of the following commands
 $ python tests/test_tutorials.py
 $ py.test
 $ python setup.py test
+
+__authors__ = "Remi Lehe, Axel Huebl"
+__copyright__ = "Copyright 2015-2016, openPMD viewer contributors"
+__license__ = "3-Clause-BSD-LBNL"
 """
+
 import os
 import re
 


### PR DESCRIPTION
Close #56 by adding a short license and author information to each file (as an open source best-practice, since files might be individually re-used in derivative projects).

The authors were taken from the individual `git log` history of each file, new authors can update the author list of edited files as they contribute.

Unified some spellings of the project in the way (lowercase "o" in "openPMD", most often written without "-" between "openPMD" and "viewer").