### PR TITLE
Multiply by unitSI only if different than 1

### DIFF
--- a/opmd_viewer/openpmd_timeseries/data_reader/utilities.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/utilities.py
@@ -89,7 +89,8 @@ def get_data(dset, i_slice=None, pos_slice=None):
             data = dset[:, :, i_slice]
 
     # Scale by the conversion factor
-    data = data * dset.attrs['unitSI']
+    if dset.attrs['unitSI'] != 1:
+        data *= dset.attrs['unitSI']
 
     return(data)
 


### PR DESCRIPTION
This makes reading data more efficient.