### PR TITLE
Replace nbins slider by a text widget

### DIFF
--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -378,8 +378,8 @@ class InteractiveViewer(object):
             ptcl_figure_button = widgets.IntText(description='Figure ',
                                                  value=1, width=50)
             # Number of bins
-            ptcl_bins_button = widgets.IntSlider(description='nbins:',
-                min=50, max=300, value=100, width=150)
+            ptcl_bins_button = widgets.IntText(description='nbins:',
+                                               value=100, width=100)
             ptcl_bins_button.observe( refresh_ptcl, 'value', 'change')
             # Colormap button
             ptcl_color_button = widgets.Select(


### PR DESCRIPTION
One of our users requested that the bins widget be a text widget instead of a slider. I actually agree with him, since changing the number of bins via a text widget is much more flexible.