### PR TITLE
unitSI != 1.0

### DIFF
--- a/opmd_viewer/openpmd_timeseries/data_reader/utilities.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/utilities.py
@@ -89,7 +89,7 @@ def get_data(dset, i_slice=None, pos_slice=None):
             data = dset[:, :, i_slice]
 
     # Scale by the conversion factor
-    if dset.attrs['unitSI'] != 1:
+    if dset.attrs['unitSI'] != 1.0:
         data *= dset.attrs['unitSI']
 
     return(data)


### PR DESCRIPTION
Follow-up to #81: avoid cast from int to floating point.