### PR TITLE
Change formatting of the copyright

### DIFF
--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -3,9 +3,9 @@ This file is part of the openPMD viewer.
 
 This file contains diagnostics relevant for laser-plasma acceleration
 
-__authors__ = "Soeren Jalas, Remi Lehe"
-__copyright__ = "Copyright 2015-2016, openPMD viewer contributors"
-__license__ = "3-Clause-BSD-LBNL"
+Copyright 2015-2016, openPMD viewer contributors
+Authors: Soeren Jalas, Remi Lehe
+License: 3-Clause-BSD-LBNL
 """
 
 # Class that inherits from OpenPMDTimeSeries, and implements

--- a/opmd_viewer/openpmd_timeseries/data_reader/field_metainfo.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/field_metainfo.py
@@ -5,9 +5,9 @@ It defines the main FieldMetaInformation class, which
 is returned by `get_field` along with the array of field values,
 and gathers information collected from the openPMD file.
 
-__authors__ = "Remi Lehe"
-__copyright__ = "Copyright 2015-2016, openPMD viewer contributors"
-__license__ = "3-Clause-BSD-LBNL"
+Copyright 2015-2016, openPMD viewer contributors
+Author: Remi Lehe
+License: 3-Clause-BSD-LBNL
 """
 
 import numpy as np

--- a/opmd_viewer/openpmd_timeseries/data_reader/field_reader.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/field_reader.py
@@ -3,9 +3,9 @@ This file is part of the openPMD viewer.
 
 It defines functions that can read the fields from an HDF5 file.
 
-__authors__ = "Remi Lehe"
-__copyright__ = "Copyright 2015-2016, openPMD viewer contributors"
-__license__ = "3-Clause-BSD-LBNL"
+Copyright 2015-2016, openPMD viewer contributors
+Author: Remi Lehe
+License: 3-Clause-BSD-LBNL
 """
 
 import os

--- a/opmd_viewer/openpmd_timeseries/data_reader/params_reader.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/params_reader.py
@@ -3,9 +3,9 @@ This file is part of the openPMD viewer.
 
 It defines a function that can read standard parameters from an openPMD file.
 
-__authors__ = "Remi Lehe, Axel Huebl"
-__copyright__ = "Copyright 2015-2016, openPMD viewer contributors"
-__license__ = "3-Clause-BSD-LBNL"
+Copyright 2015-2016, openPMD viewer contributors
+Authors: Remi Lehe, Axel Huebl
+License: 3-Clause-BSD-LBNL
 """
 
 import os

--- a/opmd_viewer/openpmd_timeseries/data_reader/particle_reader.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/particle_reader.py
@@ -4,9 +4,9 @@ This file is part of the openPMD viewer.
 It defines a function that reads a species record component (data & meta)
 from an openPMD file
 
-__authors__ = "Remi Lehe, Axel Huebl"
-__copyright__ = "Copyright 2015-2016, openPMD viewer contributors"
-__license__ = "3-Clause-BSD-LBNL"
+Copyright 2015-2016, openPMD viewer contributors
+Authors: Remi Lehe, Axel Huebl
+License: 3-Clause-BSD-LBNL
 """
 
 import os

--- a/opmd_viewer/openpmd_timeseries/data_reader/utilities.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/utilities.py
@@ -4,9 +4,9 @@ This file is part of the openPMD viewer.
 It defines a set of helper data and functions which
 are used by the other files.
 
-__authors__ = "Remi Lehe, Axel Huebl"
-__copyright__ = "Copyright 2015-2016, openPMD viewer contributors"
-__license__ = "3-Clause-BSD-LBNL"
+Copyright 2015-2016, openPMD viewer contributors
+Authors: Remi Lehe, Axel Huebl
+License: 3-Clause-BSD-LBNL
 """
 
 import h5py

--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -4,9 +4,9 @@ This file is part of the openPMD viewer.
 It defines an interactive interface for the viewer,
 based on the IPython notebook functionalities
 
-__authors__ = "Remi Lehe, Axel Huebl"
-__copyright__ = "Copyright 2015-2016, openPMD viewer contributors"
-__license__ = "3-Clause-BSD-LBNL"
+Copyright 2015-2016, openPMD viewer contributors
+Authors: Remi Lehe, Axel Huebl
+License: 3-Clause-BSD-LBNL
 """
 
 try:

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -3,9 +3,9 @@ This file is part of the openPMD viewer.
 
 It defines the main OpenPMDTimeSeries class.
 
-__authors__ = "Remi Lehe, Axel Huebl"
-__copyright__ = "Copyright 2015-2016, openPMD viewer contributors"
-__license__ = "3-Clause-BSD-LBNL"
+Copyright 2015-2016, openPMD viewer contributors
+Authors: Remi Lehe, Axel Huebl
+License: 3-Clause-BSD-LBNL
 """
 
 import os

--- a/opmd_viewer/openpmd_timeseries/plotter.py
+++ b/opmd_viewer/openpmd_timeseries/plotter.py
@@ -4,9 +4,9 @@ This file is part of the openPMD viewer.
 It defines a set of methods which are useful for plotting
 (and labeling the plots).
 
-__authors__ = "Remi Lehe"
-__copyright__ = "Copyright 2015-2016, openPMD viewer contributors"
-__license__ = "3-Clause-BSD-LBNL"
+Copyright 2015-2016, openPMD viewer contributors
+Author: Remi Lehe
+License: 3-Clause-BSD-LBNL
 """
 
 import matplotlib.pyplot as plt

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -10,9 +10,9 @@ $ python tests/test_tutorials.py
 $ py.test
 $ python setup.py test
 
-__authors__ = "Remi Lehe, Axel Huebl"
-__copyright__ = "Copyright 2015-2016, openPMD viewer contributors"
-__license__ = "3-Clause-BSD-LBNL"
+Copyright 2015-2016, openPMD viewer contributors
+Authors: Remi Lehe, Axel Huebl
+License: 3-Clause-BSD-LBNL
 """
 
 import os


### PR DESCRIPTION
It does not really make sense to use the Python synthax (like `__license__ = "3-Clause-BSD-LBNL"`) inside a comment, since this does not define the variable `__license__` anyway.

Therefore, I rewrote these part in more human-friendly way. This is only a suggestion.