### PR TITLE
Drop support for IPython.html

### DIFF
--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -9,13 +9,7 @@ Authors: Remi Lehe, Axel Huebl
 License: 3-Clause-BSD-LBNL
 """
 
-try:
-    from ipywidgets import widgets
-except ImportError:
-    # If ipywidgets is not available, use the deprecated package
-    # IPython.html.widgets, so that the GUI still works
-    from IPython.html import widgets
-
+from ipywidgets import widgets
 from IPython.display import display, clear_output
 import math
 import matplotlib


### PR DESCRIPTION
Since we started using `observe` instead of the deprecated `on_trait_change` in `interactive.py`, we effectively stopped supporting the deprecated widget package `IPython.html`, and started only supporting `ipywidgets` (which is the official widget package for Python).

This PR makes it more explicit, by raising a message (see main.py) if `ipywidgets` is not installed.