### PR TITLE
Added ´check_all_files´ flag to LPA diagnostic class init

### DIFF
--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -31,7 +31,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             one file per iteration, and the name of the files should end
             with the iteration number, followed by '.h5' (e.g. data0005000.h5)
         """
-        OpenPMDTimeSeries.__init__( self, path_to_dir, 
+        OpenPMDTimeSeries.__init__( self, path_to_dir,
                                     check_all_files=check_all_files )
 
     def get_mean_gamma( self, t=None, iteration=None, species=None,

--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -18,7 +18,7 @@ import scipy.constants as const
 
 class LpaDiagnostics( OpenPMDTimeSeries ):
 
-    def __init__( self, path_to_dir ):
+    def __init__( self, path_to_dir, check_all_files=True ):
         """
         Initialize an OpenPMD time series with various methods to diagnose the
         data
@@ -31,7 +31,8 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             one file per iteration, and the name of the files should end
             with the iteration number, followed by '.h5' (e.g. data0005000.h5)
         """
-        OpenPMDTimeSeries.__init__( self, path_to_dir )
+        OpenPMDTimeSeries.__init__( self, path_to_dir, 
+                                    check_all_files=check_all_files )
 
     def get_mean_gamma( self, t=None, iteration=None, species=None,
                         select=None ):

--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -30,6 +30,12 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             For the moment, only HDF5 files are supported. There should be
             one file per iteration, and the name of the files should end
             with the iteration number, followed by '.h5' (e.g. data0005000.h5)
+
+        check_all_files: bool, optional
+            Check that all the files in the timeseries are consistent
+            (i.e. that they contain the same fields and particles,
+            with the same metadata)
+            For fast access to the files, this can be changed to False.
         """
         OpenPMDTimeSeries.__init__( self, path_to_dir,
                                     check_all_files=check_all_files )


### PR DESCRIPTION
Resolve #98 first.

Hi,
As the OpenPMDTimeSeries init() method is called when creating an instance of LpaDiagnostics, the flag `check_all_files` needed to be added there as well.