### PR TITLE
Import numpy and matplotlib in the template notebook

### DIFF
--- a/opmd_viewer/notebook_starter/Template_notebook.ipynb
+++ b/opmd_viewer/notebook_starter/Template_notebook.ipynb
@@ -1,16 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This is a pre-filled notebook, for the visualization of openPMD files.\n",
-    "\n",
-    "- Modify the path in cell 2, so that it points to your data\n",
-    "- Click `Cell > Run all` in the above menu"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -18,11 +8,10 @@
    },
    "outputs": [],
    "source": [
-    "# Import relevant packages and setup visualization\n",
-    "# NB: The default setup produces pop-up windows for the plots.\n",
-    "# To include the plots in the notebook, use `%matplotlib notebook`.\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
     "from opmd_viewer import OpenPMDTimeSeries\n",
-    "%matplotlib"
+    "%matplotlib # or `%matplotlib notebook` for inline plots"
    ]
   },
   {
@@ -33,7 +22,7 @@
    },
    "outputs": [],
    "source": [
-    "# Point to the folder containing the openPMD files\n",
+    "# Replace the string below, to point to your data\n",
     "ts = OpenPMDTimeSeries('./diags/hdf5/')"
    ]
   },
@@ -45,7 +34,7 @@
    },
    "outputs": [],
    "source": [
-    "# Create the interactive GUI\n",
+    "# Interactive GUI\n",
     "ts.slider()"
    ]
   }


### PR DESCRIPTION
I updated the template notebook that one gets when typing `openPMD_notebook`.
In particular, I import numpy and matplotlib by default, since I always find that I need to import them in practical situations.