### PR TITLE
Modify default record when species is changed

### DIFF
--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -182,9 +182,8 @@ class InteractiveViewer(object):
             ptcl_refresh_toggle.value = False
 
             # Get available records for this species
-            avail_records = [q for q in
-                             self.avail_record_components[
-                                 ptcl_species_button.value]
+            avail_records = [q for q in self.avail_record_components[
+                             ptcl_species_button.value]
                              if q not in exclude_particle_records]
             # Update the plotting buttons
             ptcl_xaxis_button.options = avail_records

--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -188,9 +188,11 @@ class InteractiveViewer(object):
                              if q not in exclude_particle_records]
             # Update the plotting buttons
             ptcl_xaxis_button.options = avail_records
-            ptcl_xaxis_button.value = avail_records[0]
             ptcl_yaxis_button.options = avail_records + ['None']
-            ptcl_yaxis_button.value = 'None'
+            if ptcl_xaxis_button.value not in ptcl_xaxis_button.options:
+                ptcl_xaxis_button.value = avail_records[0]
+            if ptcl_yaxis_button.value not in ptcl_yaxis_button.options:
+                ptcl_yaxis_button.value = 'None'
 
             # Update the selection widgets
             for dropdown_button in ptcl_select_widget.quantity:


### PR DESCRIPTION
In the GUI, when the species is changed, the current observed quantity (e.g. 'z', 'uz') used to annoyingly be reset to 'x'. This pull request changes this.