### PR TITLE
Install instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,7 @@ before_install:
 
 # Install packages
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION h5py
-  - pip install -r requirements.txt
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION --file requirements.txt
   - python setup.py install
   - pip install wget
   - pip install pyflakes pep8 jupyter

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,8 @@ before_install:
 
 # Install packages
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION --file requirements.txt
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION jupyter
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION pyflakes
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION pep8
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION scipy matplotlib h5py jupyter
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION pyflakes pep8
   - python setup.py install
 
 before_script :

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_install:
 install:
   - conda install --yes python=$TRAVIS_PYTHON_VERSION scipy matplotlib h5py jupyter
   - conda install --yes python=$TRAVIS_PYTHON_VERSION pyflakes pep8
+  - pip install wget
   - python setup.py install
 
 before_script :

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,11 @@ before_install:
 
 # Install packages
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION scipy matplotlib h5py jupyter
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION pyflakes pep8
-  - pip install wget
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION h5py
+  - pip install -r requirements.txt
   - python setup.py install
+  - pip install wget
+  - pip install pyflakes pep8 jupyter
 
 before_script :
   # static code analysis

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,10 @@ git clone git@github.com:<YourUserLogin>/openPMD-viewer.git
 ```
 git checkout dev
 ```
+and install it
+```
+python setup.py install
+```
 
 - Start a new branch from the development branch, in order to
 implement a new feature. (Choose a branch name that is representative of the
@@ -52,6 +56,7 @@ ensure that your code complies with some standard style conventions.
   ```
   - Make sure that the tests pass
   ```
+  python setup.py install
   python setup.py test
   ```
   (Be patient: the `test_tutorials.py` can take approx. 20 seconds if

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ ensure that your code complies with some standard style conventions.
   pyflakes opmd_viewer
   pep8 --ignore=E201,E202,E122,E127,E128,E131 opmd_viewer
   ```
-  - Make sure that the tests pass
+  - Make sure that the tests pass (please install `wget` and `jupyter` before running the tests: `pip install wget jupyter`)
   ```
   python setup.py install
   python setup.py test

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ the API and the interactive GUI. You can view these notebooks online
 
 You can also download and run these notebooks on your local computer
 (when viewing the notebooks with the above link, click on `Raw` to be able to
-save them to your local computer).
+save them to your local computer). In order to run the notebook on
+your local computer, please install `openPMD-viewer` first (see
+below), as well as `wget` (`pip install wget`).
 
 ### Notebook quick-starter
 
@@ -41,7 +43,7 @@ browser**. To use this executable, simply type in a regular terminal:
 
 `openPMD_notebook`
 
-(This executable is installed by default.)
+(This executable is installed by default, when installing `openPMD-viewer`.)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -12,77 +12,71 @@ This package contains a set of tools to load and visualize the
 contents of a set of [openPMD](http://www.openpmd.org/#/start) files
 (typically, a timeseries).
 
-## Installation
-
-### Basic installation
-
-To install this package :
-
-- Clone this repository using `git`
-```
-git clone https://github.com/openPMD/openPMD-viewer.git
-```
-
-- `cd` into the directory `openPMD-viewer` and run
-```
-python setup.py install
-```
-
-### Installing the interactive GUI
-
-The **interactive GUI** for IPython Notebook is not
-operational by default.
-
-This is because it requires dependencies that may be difficult to
-install on some systems. If you wish to have the interactive GUI
-working, install the
-[IPython Notebook](http://ipython.org/notebook.html)
-(now part of the [Jupyter project](http://jupyter.org/)) by hand:
-
-`conda install jupyter` (for the
-[Anaconda](https://www.continuum.io/downloads)
-distribution) or `pip install jupyter` (for the other Python distributions)
-
-NB: For [NERSC](http://www.nersc.gov/) users, it is not necessary to
-install the above package, as NERSC provides it when logging to
-[https://ipython.nersc.gov](https://ipython.nersc.gov).
-Therefore, NERSC users only need to install the `openPMD-viewer`
-package itself.
-
-## Usage
-
-The routines of openPMD-viewer can be used in two ways :
+The routines of `openPMD-viewer` can be used in two ways :
 
 - Use the **Python API**, in order to write a script that loads the
   data and produces a set of pre-defined plots.
 
-- Use the **interactive GUI inside the IPython Notebook**, in order to interactively
+- Use the **interactive GUI inside the Jupyter Notebook**, in order to interactively
 visualize the data.
+
+## Installation
+
+### Installation on a local computer, using Anaconda
+
+On a local computer, it is recommended to install the [Anaconda
+distribution](https://www.continuum.io/downloads), which enables an easy
+installation of the dependencies of `openPMD-viewer`.
+
+Once Anaconda is installed, type
+```
+conda install scipy matplolib h5py jupyter
+pip install openPMD-viewer
+```
+The first line installs the dependencies, while the second line
+installs `openPMD-viewer` itself
+
+### Installation on a remote scientific cluster
+
+If you wish to install the `openPMD-viewer` on a remote scientific
+cluster, please make sure that packages `numpy`, `scipy` and `h5py`
+are available in your environment. This is typically done by a set of
+`module load` commands (e.g. `module load h5py`) -- please refer to
+the documentation of your scientific cluster.
+
+Then type
+```
+pip install openPMD-viewer --user
+```
+
+Note: The package `jupyter` is only required for the **interactive
+GUI** and thus it does not need to be installed if you are only using
+the **Python API**.  For [NERSC](http://www.nersc.gov/) users, access to Jupyter
+notebooks is provided when logging to
+[https://ipython.nersc.gov](https://ipython.nersc.gov).
+
+## Usage
 
 ### Tutorials
 
 The notebooks in the folder `tutorials/` demonstrate how to use both
 the API and the interactive GUI. You can view these notebooks online
-[here](https://github.com/openPMD/openPMD-viewer/tree/master/tutorials),
-or, alternatively, you can run them on your local computer by typing:
+[here](https://github.com/openPMD/openPMD-viewer/tree/master/tutorials).
 
-`ipython notebook tutorials/`
-
-NB: For [NERSC](http://www.nersc.gov/) users, you can run the tutorials on a
-remote machine by logging in at
-[https://ipython.nersc.gov](https://ipython.nersc.gov), and by
-navigating to your personal copy of the directory `openPMD-viewer/tutorials`.
+You can also download and run these notebooks on your local computer
+(when viewing the notebooks with the above link, click on `Raw` to be able to
+save them to your local computer).
 
 ### Notebook quick-starter
 
-If you wish to use the **interactive GUI**, the installation of `openPMD-viewer` provides
-a convenient executable which automatically
+If you wish to use the **interactive GUI**, the installation of
+`openPMD-viewer` provides a convenient executable which automatically
 **creates a new pre-filled notebook** and **opens it in a
 browser**. To use this executable, simply type in a regular terminal:
 
 `openPMD_notebook`
 
-(This executable is installed by default when running `python setup.py install`.)
+(This executable is installed by default.)
 
 ## Contributing to the openPMD-viewer
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,29 @@ The routines of `openPMD-viewer` can be used in two ways :
 - Use the **interactive GUI inside the Jupyter Notebook**, in order to interactively
 visualize the data.
 
+## Usage
+
+### Tutorials
+
+The notebooks in the folder `tutorials/` demonstrate how to use both
+the API and the interactive GUI. You can view these notebooks online
+[here](https://github.com/openPMD/openPMD-viewer/tree/master/tutorials).
+
+You can also download and run these notebooks on your local computer
+(when viewing the notebooks with the above link, click on `Raw` to be able to
+save them to your local computer).
+
+### Notebook quick-starter
+
+If you wish to use the **interactive GUI**, the installation of
+`openPMD-viewer` provides a convenient executable which automatically
+**creates a new pre-filled notebook** and **opens it in a
+browser**. To use this executable, simply type in a regular terminal:
+
+`openPMD_notebook`
+
+(This executable is installed by default.)
+
 ## Installation
 
 ### Installation on a local computer, using Anaconda
@@ -54,29 +77,6 @@ GUI** and thus it does not need to be installed if you are only using
 the **Python API**.  For [NERSC](http://www.nersc.gov/) users, access to Jupyter
 notebooks is provided when logging to
 [https://ipython.nersc.gov](https://ipython.nersc.gov).
-
-## Usage
-
-### Tutorials
-
-The notebooks in the folder `tutorials/` demonstrate how to use both
-the API and the interactive GUI. You can view these notebooks online
-[here](https://github.com/openPMD/openPMD-viewer/tree/master/tutorials).
-
-You can also download and run these notebooks on your local computer
-(when viewing the notebooks with the above link, click on `Raw` to be able to
-save them to your local computer).
-
-### Notebook quick-starter
-
-If you wish to use the **interactive GUI**, the installation of
-`openPMD-viewer` provides a convenient executable which automatically
-**creates a new pre-filled notebook** and **opens it in a
-browser**. To use this executable, simply type in a regular terminal:
-
-`openPMD_notebook`
-
-(This executable is installed by default.)
 
 ## Contributing to the openPMD-viewer
 

--- a/README.md
+++ b/README.md
@@ -47,24 +47,28 @@ browser**. To use this executable, simply type in a regular terminal:
 
 ## Installation
 
-### Installation on a local computer, using Anaconda
+### Installation on a local computer
 
-On a local computer, it is recommended to install the [Anaconda
-distribution](https://www.continuum.io/downloads), which enables an easy
-installation of the dependencies of `openPMD-viewer`.
+Before installing `openPMD-viewer`, please make sure that `h5py` is
+installed on your local computer. (If you are using the [Anaconda
+distribution](https://www.continuum.io/downloads), this can be done by
+typing `conda install h5py`. Otherwise, use `pip install h5py`, though
+this may require you to install `hdf5` separately.)
 
-Once Anaconda is installed, type
+Once `h5py` is installed, simply type
 ```
-conda install scipy matplolib h5py jupyter
 pip install openPMD-viewer
 ```
-The first line installs the dependencies, while the second line
-installs `openPMD-viewer` itself
+
+In addition, if you wish to use the interactive GUI, please type
+```
+pip install jupyter
+```
 
 ### Installation on a remote scientific cluster
 
 If you wish to install the `openPMD-viewer` on a remote scientific
-cluster, please make sure that packages `numpy`, `scipy` and `h5py`
+cluster, please make sure that the packages `numpy`, `scipy` and `h5py`
 are available in your environment. This is typically done by a set of
 `module load` commands (e.g. `module load h5py`) -- please refer to
 the documentation of your scientific cluster.

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,6 @@ except (ImportError, RuntimeError):
 # Get the package requirements from the requirements.txt file
 with open('./requirements.txt') as f:
     install_requires = [line.strip('\n') for line in f.readlines()]
-# Since wget cannot be installed with conda, it is added separately here
-install_requires.append('wget')
 
 # Main setup command
 setup(name='openPMD-viewer',


### PR DESCRIPTION
I changed the installation instructions to make them compatible with the future `pip` distribution.

I also put the **Usage** section first in the README, in order to encourage the users to go look the tutorials. (Before this, they had to read through the installation instructions for various systems, before learning about the existence of the tutorials. I guess most users would stop reading before then.)