### PR TITLE
Bad evaluation of the waist

### DIFF
--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -694,13 +694,14 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
                                                 pol=pol, index='all',
                                                 slicing_dir=slicing_dir,
                                                 theta=theta)
-
-        # Find the maximum of the envelope along the transverse axis
-        trans_max = np.amax(field, axis=1)
+        # Find the indices of the maximum field, and
+        # pick the corresponding transverse slice
+        _, iz_max = np.unravel_index( np.argmax( field ), dims=field.shape )
+        trans_slice = field[ :, iz_max ]
         # Get transverse positons
         trans_pos = getattr(info, info.axes[0])
         # Calculate standard deviation
-        sigma_r = wstd(trans_pos, trans_max)
+        sigma_r = wstd(trans_pos, trans_slice)
         # Return the laser waist = sqrt(2) * sigma_r
         return(np.sqrt(2) * sigma_r)
 

--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -16,6 +16,7 @@ import numpy as np
 import scipy.constants as const
 from scipy.optimize import curve_fit
 
+
 class LpaDiagnostics( OpenPMDTimeSeries ):
 
     def __init__( self, path_to_dir, check_all_files=True ):
@@ -713,16 +714,16 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         w0 = np.sqrt(2) * wstd(trans_pos, trans_slice)
         if method == 'rms':
             return( w0 )
-        
+
         # Compute waist with Gaussian fit
-        elif method=='fit':
+        elif method == 'fit':
             # Get initial guess for the amplitude
             E0 = field[ itrans_max, iz_max ]
             # Perform the fit
             params, _ = curve_fit( gaussian_profile, trans_pos,
                                    trans_slice, p0=[ E0, w0 ])
             return( params[1] )
-            
+
         else:
             raise ValueError('Unknown method: {:s}'.format(method))
 
@@ -869,5 +870,4 @@ def gaussian_profile( x, E0, w0 ):
     -------
     A 1darray of floats, of the same length as x
     """
-    return( E0*np.exp( -x**2/w0**2 ) )
-    
+    return( E0 * np.exp( -x**2 / w0**2 ) )

--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -14,7 +14,7 @@ from opmd_viewer import OpenPMDTimeSeries, FieldMetaInformation
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.constants as const
-
+from scipy.optimize import curve_fit
 
 class LpaDiagnostics( OpenPMDTimeSeries ):
 
@@ -658,7 +658,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         return( np.sqrt(2) * sigma )
 
     def get_laser_waist( self, t=None, iteration=None, pol=None, theta=0,
-                         slicing_dir='y' ):
+                         slicing_dir='y', method='fit' ):
         """
         Calculate the waist of a (gaussian) laser pulse. ( sqrt(2) * sigma_r)
 
@@ -685,6 +685,12 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
            The direction along which to slice the data
            Either 'x', 'y'
 
+        method : str, optional
+           The method which is used to compute the waist
+           'fit': Gaussian fit of the transverse profile
+           'rms': RMS radius, weighted by the transverse profile
+           ('rms' tends to give more weight to the "wings" of the pulse)
+
         Returns
         -------
         Float with laser waist in meters
@@ -696,14 +702,29 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
                                                 theta=theta)
         # Find the indices of the maximum field, and
         # pick the corresponding transverse slice
-        _, iz_max = np.unravel_index( np.argmax( field ), dims=field.shape )
+        itrans_max, iz_max = np.unravel_index(
+            np.argmax( field ), dims=field.shape )
         trans_slice = field[ :, iz_max ]
         # Get transverse positons
         trans_pos = getattr(info, info.axes[0])
-        # Calculate standard deviation
-        sigma_r = wstd(trans_pos, trans_slice)
-        # Return the laser waist = sqrt(2) * sigma_r
-        return(np.sqrt(2) * sigma_r)
+
+        # Compute waist with RMS value
+        # (serves as initial guess when method=='fit')
+        w0 = np.sqrt(2) * wstd(trans_pos, trans_slice)
+        if method == 'rms':
+            return( w0 )
+        
+        # Compute waist with Gaussian fit
+        elif method=='fit':
+            # Get initial guess for the amplitude
+            E0 = field[ itrans_max, iz_max ]
+            # Perform the fit
+            params, _ = curve_fit( gaussian_profile, trans_pos,
+                                   trans_slice, p0=[ E0, w0 ])
+            return( params[1] )
+            
+        else:
+            raise ValueError('Unknown method: {:s}'.format(method))
 
     def get_spectrogram( self, t=None, iteration=None, pol=None, theta=0,
                           slicing_dir='y', plot=False, **kw ):
@@ -826,3 +847,27 @@ def wstd( a, weights ):
         average = np.average(a, weights=weights)
         variance = np.average((a - average) ** 2, weights=weights)
         return( np.sqrt(variance) )
+
+
+def gaussian_profile( x, E0, w0 ):
+    """
+    Returns a Gaussian profile with amplitude E0 and waist w0.
+    (Used in order to fit the transverse laser profile and find the waist.)
+
+    Parameters
+    ----------
+    x: 1darray of floats
+        An array of transverse positions (in meters)
+
+    E0: float
+        The amplitude at the peak of the profile
+
+    w0: float
+        The waist of the profile
+
+    Returns
+    -------
+    A 1darray of floats, of the same length as x
+    """
+    return( E0*np.exp( -x**2/w0**2 ) )
+    


### PR DESCRIPTION
# Summary

I found that the method `get_laser_waist` gives quite a bad estimation of the waist for 2 reasons:
- The extraction of a transverse slice (from a 2D map of the envelope) uses `np.amax`
- The waist is evaluated with an RMS, instead of doing a Gaussian fit

I corrected those two limitations. Below is a more in-depth explanation of the problems with the evaluation of the waist.

# Explanation

## The problem

I recently did a simulation which involved self-focusing. Here is how the evolution of the waist and a0 look like, when evaluated with openPMD-viewer:
![waist_before](https://cloud.githubusercontent.com/assets/6685781/16394992/a90cad20-3c6c-11e6-8389-931db5d469f7.png)
However, something is quite shocking: the a0 changes a lot compared to the vacuum prediction (indicating strong self-focusing) while the waist changes very little compared to the vacuum prediction (indicating a low amount of self-focusing).

## Extraction of a transverse slice

Part of the problem is that the transverse slice is extracted by using `np.amax( ... , axis=1)`. This searches for the position of the maximum of the fields **independently for each radial position**. Therefore, the extracted profile is taken along a **curved path** that follows the maximum of the field (blue curve in the top panel below), instead of being taken along a straight transverse slide (green curve in the top panel below). Thus -- especially for peanut-shaped laser pulse -- the extracted field profile can look quite different from the  field profile in a straight transverse slice (see bottom panel), and of course the evaluation of the waist will be affected.
![figure_1](https://cloud.githubusercontent.com/assets/6685781/16395213/9dad8ea8-3c6d-11e6-943b-31ec2a109a68.png)
I corrected this issue by taken a normal, straight transverse slice. 

Here is the new evolution of the waist with this method. It is better, but not quite credible yet. 
![waist_better](https://cloud.githubusercontent.com/assets/6685781/16395271/ddc90dbe-3c6d-11e6-87f1-dae8b627a966.png)

## Fitting of a Gaussian

The remaining problem is that the field profile (green curve above) has wings, and thus the current RMS calculation of the waist will give a strong weight to these wings and overestimate the waist. By contrast, fitting a Gaussian pulse gives a much better estimation of the waist (see figure below with a Gaussian fit in dashed line)

![fit](https://cloud.githubusercontent.com/assets/6685781/16395337/2b1101f8-3c6e-11e6-9515-cc1a4cced508.png)

Here is the corresponding evolution of the waist, when evaluated with the fitting method. I looks much more credible.

![with_fit](https://cloud.githubusercontent.com/assets/6685781/16395387/6895403e-3c6e-11e6-9e7c-c5feacd42fc3.png)

In the code, I kept the option to use the RMS method ,but the user needs to specify it. By default, the fitting method is used. 



