### PR TITLE
Added fitting method to ctau calculation

### DIFF
--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -638,9 +638,9 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             Polarization of the field. Options are 'x', 'y'
 
         method : str, optional
-           The method which is used to compute the waist
-           'fit': Gaussian fit of the transverse profile
-           'rms': RMS radius, weighted by the transverse profile
+           The method which is used to compute ctau
+           'fit': Gaussian fit of the longitudinal profile
+           'rms': RMS radius, weighted by the longitudinal profile
            ('rms' tends to give more weight to the "wings" of the pulse)
 
         Returns
@@ -676,7 +676,6 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
 
         else:
             raise ValueError('Unknown method: {:s}'.format(method))
-
 
     def get_laser_waist( self, t=None, iteration=None, pol=None, theta=0,
                          slicing_dir='y', method='fit' ):
@@ -872,7 +871,7 @@ def wstd( a, weights ):
         return( np.sqrt(variance) )
 
 
-def gaussian_profile( x,x0, E0, w0 ):
+def gaussian_profile( x, x0, E0, w0 ):
     """
     Returns a Gaussian profile with amplitude E0 and waist w0.
     (Used in order to fit the transverse laser profile and find the waist.)
@@ -895,4 +894,4 @@ def gaussian_profile( x,x0, E0, w0 ):
     -------
     A 1darray of floats, of the same length as x
     """
-    return( E0 * np.exp( -(x-x0)**2 / w0**2 ) )
+    return( E0 * np.exp( -(x - x0) ** 2 / w0 ** 2 ) )

--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -666,12 +666,13 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
 
         # Calculate ctau from Gaussian fit
         elif method == 'fit':
-            # Start value for E0 in fit
+            # Start value for E0 and x0 in fit
             E0 = np.amax( E )
+            z0 = info.z[np.argmax( E )]
             # Perform the fit
             params, _ = curve_fit( gaussian_profile, info.z,
-                                   E, p0=[ E0, ctau ])
-            return( params[1] )
+                                   E, p0=[ z0, E0, ctau ])
+            return( params[2] )
 
         else:
             raise ValueError('Unknown method: {:s}'.format(method))
@@ -738,10 +739,12 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         elif method == 'fit':
             # Get initial guess for the amplitude
             E0 = field[ itrans_max, iz_max ]
+            # Assume that the pulse is centered
+            x0 = 0
             # Perform the fit
             params, _ = curve_fit( gaussian_profile, trans_pos,
-                                   trans_slice, p0=[ E0, w0 ])
-            return( params[1] )
+                                   trans_slice, p0=[x0, E0, w0 ])
+            return( params[2] )
 
         else:
             raise ValueError('Unknown method: {:s}'.format(method))
@@ -869,7 +872,7 @@ def wstd( a, weights ):
         return( np.sqrt(variance) )
 
 
-def gaussian_profile( x, E0, w0 ):
+def gaussian_profile( x,x0, E0, w0 ):
     """
     Returns a Gaussian profile with amplitude E0 and waist w0.
     (Used in order to fit the transverse laser profile and find the waist.)
@@ -878,6 +881,9 @@ def gaussian_profile( x, E0, w0 ):
     ----------
     x: 1darray of floats
         An array of transverse positions (in meters)
+
+    x0: float
+        Position of the peak of the profile
 
     E0: float
         The amplitude at the peak of the profile
@@ -889,4 +895,4 @@ def gaussian_profile( x, E0, w0 ):
     -------
     A 1darray of floats, of the same length as x
     """
-    return( E0 * np.exp( -x**2 / w0**2 ) )
+    return( E0 * np.exp( -(x-x0)**2 / w0**2 ) )


### PR DESCRIPTION
This PR adds, just like #111,  the option to calculate the pulse length by fitting the beam envelope to a Gaussian profile. The `gaussian_profile` method had to be modified to allow for non-centered profiles.