### PR TITLE
Add option to calculate central laser frequency by Gaussian fitting

### DIFF
--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -515,7 +515,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             # Guess start values for fit
             f0 = omega0
             fmax = np.amax( spectrum )
-            fsigma = wstd(spectrum, info.omega)
+            fsigma = info.omegamax - info.omegamin
             params, _ = curve_fit( gaussian_profile, info.omega,
                                    spectrum, p0=[f0, fmax, fsigma])
             return( params[0] )


### PR DESCRIPTION
As proposed in #115, I added the option to use a Gaussian fit ( love scipy.optimize! 😊) in the `get_main_frequency` method. The user has now the option to use the old method where only the frequency with the highest intensity in the spectrum is returned or use the new method by giving the option `method='max'` or `method='fit'`.

I compared the two cases with some LWFA simulation data I had (pulse from experiment, so spectrum not necessarily Gaussian):
#### Initial spectrum
<img src="https://cloud.githubusercontent.com/assets/10922951/16593976/4cc61fb0-42e8-11e6-94f6-bbe27c9c3763.png"  width="400px">

#### With  `method='fit'`
<img src="https://cloud.githubusercontent.com/assets/10922951/16593333/1287ce14-42e5-11e6-957b-90af8adb406e.png"  width="400px">

#### With `method='max'`
<img src="https://cloud.githubusercontent.com/assets/10922951/16593334/13cfe3f6-42e5-11e6-8a0c-f7acc3290180.png"  width="400px">

It seems that the new method creates a little more compatible data, when looking at the pulse evolution. However, I noticed that the fit seems to be quite sensitive to the start value of the width of the Gaussian.
When I used the standard deviation of the spectrum the fit always resulted in really slim peaks around the maximum of the spectrum and gave the same result as the `method='max'` version. Now I use the width of the full spectrum as a start value and it seems to give good results.

All in all I think we should test this on a few more cases before adding it to a release version just to see if it behaves properly in all cases.