### PR TITLE
Revert to evaluating laser frequency with max

### DIFF
--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -512,7 +512,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         return( envelope )
 
     def get_main_frequency( self, t=None, iteration=None, pol=None, m='all',
-                            method='fit'):
+                            method='max'):
         """
         Calculate the angular frequency of a laser pulse.
 


### PR DESCRIPTION
When testing the new `get_main_frequency` (with method=`fit`), I encountered several problems. As @soerenjalas already warned, the fit is not very robust. In some cases, I found that it returned negative frequencies... This is quite inconvenient, especially as this function is called e.g. in `get_a0`.

I propose that we keep the `fit` method (as it is also quite convenient in some cases, as shown by @soerenjalas in his pull request), but that the default is to use `max`, which is more robust.