### PR TITLE
Modified tests in preparation for conda release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-[bdist_wheel]
-# This flag indicates that the code is written both for Python 2 and 3
-universal=1
-
-[aliases]
-test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
+import sys
 from setuptools import setup, find_packages
+from setuptools.command.test import test as TestCommand
 
 # Get the long description
 # If possible, use pypandoc to convert the README from Markdown
@@ -12,6 +14,14 @@ except (ImportError, RuntimeError):
 with open('./requirements.txt') as f:
     install_requires = [line.strip('\n') for line in f.readlines()]
 
+# Define a custom class to run the py.test with `python setup.py test`
+class PyTest(TestCommand):
+
+    def run_tests(self):
+        import pytest
+        errcode = pytest.main([])
+        sys.exit(errcode)
+
 # Main setup command
 setup(name='openPMD-viewer',
       version='0.3.0',
@@ -24,9 +34,9 @@ setup(name='openPMD-viewer',
       packages=find_packages('./'),
       package_data={'opmd_viewer': ['notebook_starter/*.ipynb']},
       scripts=['opmd_viewer/notebook_starter/openPMD_notebook'],
-      install_requires=install_requires,
       tests_require=['pytest', 'jupyter'],
-      setup_requires=['pytest-runner'],
+      install_requires=install_requires,
+      cmdclass={'test': PyTest},
       platforms='any',
       classifiers=[
           'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ except (ImportError, RuntimeError):
 with open('./requirements.txt') as f:
     install_requires = [line.strip('\n') for line in f.readlines()]
 
+
 # Define a custom class to run the py.test with `python setup.py test`
 class PyTest(TestCommand):
 


### PR DESCRIPTION
The line `setup_requires=['pytest-runner']` in `setup.py` made it difficult to integrate openPMD-viewer with conda (because `pytest-runner` is not in the standard conda channels).

Therefore, I rewrote parts of the `setup.py`, in order to avoid using `pytest-runner` and yet still be able to launch the command `python setup.py test`. I used the documentation of `pytest`: http://doc.pytest.org/en/latest/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner 