### PR TITLE
Grid aliasing

### DIFF
--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -136,7 +136,8 @@ class InteractiveViewer(object):
                         select=ptcl_select_widget.to_dict(),
                         species=ptcl_species_button.value, plot=True,
                         vmin=vmin, vmax=vmax, cmap=ptcl_color_button.value,
-                        nbins=ptcl_bins_button.value)
+                        nbins=ptcl_bins_button.value,
+                        use_field_mesh=ptcl_use_field_button.value )
                 else:
                     # 2D histogram
                     self.get_particle(t=self.current_t, output=False,
@@ -145,7 +146,8 @@ class InteractiveViewer(object):
                         select=ptcl_select_widget.to_dict(),
                         species=ptcl_species_button.value, plot=True,
                         vmin=vmin, vmax=vmax, cmap=ptcl_color_button.value,
-                        nbins=ptcl_bins_button.value)
+                        nbins=ptcl_bins_button.value,
+                        use_field_mesh=ptcl_use_field_button.value )
 
         def refresh_field_type(change):
             """
@@ -389,7 +391,7 @@ class InteractiveViewer(object):
             set_widget_dimensions( ptcl_figure_button, width=50 )
             # Number of bins
             ptcl_bins_button = widgets.IntText(description='nbins:', value=100)
-            set_widget_dimensions( ptcl_bins_button, width=100 )
+            set_widget_dimensions( ptcl_bins_button, width=80 )
             ptcl_bins_button.observe( refresh_ptcl, 'value', 'change')
             # Colormap button
             ptcl_color_button = widgets.Select(
@@ -411,6 +413,11 @@ class InteractiveViewer(object):
                 description=' Use this range', value=False)
             set_widget_dimensions( ptcl_use_button, left_margin=100 )
             ptcl_use_button.observe( refresh_ptcl, 'value', 'change')
+            # Use field mesh buttons
+            ptcl_use_field_button = widgets.Checkbox(
+                description=' Use field mesh', value=True)
+            set_widget_dimensions( ptcl_use_field_button, left_margin=90 )
+            ptcl_use_field_button.observe( refresh_ptcl, 'value', 'change')
             # Resfresh buttons
             ptcl_refresh_toggle = widgets.ToggleButton(
                 description='Always refresh', value=True)
@@ -427,12 +434,14 @@ class InteractiveViewer(object):
             # Particle selection container
             container_ptcl_select = ptcl_select_widget.to_container()
             # Plotting options container
+            container_ptcl_bins = widgets.HBox( children=[
+                ptcl_bins_button, ptcl_use_field_button ] )
             container_ptcl_magnitude = widgets.HBox( children=[
                 ptcl_magnitude_button, ptcl_use_button ] )
             set_widget_dimensions( container_ptcl_magnitude, height=50 )
             container_ptcl_plots = widgets.VBox( children=[
-                ptcl_figure_button, ptcl_bins_button, ptcl_range_button,
-                container_ptcl_magnitude, ptcl_color_button])
+                ptcl_figure_button, container_ptcl_bins, ptcl_range_button,
+                container_ptcl_magnitude, ptcl_color_button ])
             set_widget_dimensions( container_ptcl_plots, width=310 )
             # Accordion for the field widgets
             accord2 = widgets.Accordion(

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -9,9 +9,9 @@ License: 3-Clause-BSD-LBNL
 """
 
 import os
-import re
 import numpy as np
 import h5py as h5
+from .utilities import list_h5_files, apply_selection
 from .plotter import Plotter
 from .data_reader.params_reader import read_openPMD_params
 from .data_reader.particle_reader import read_species_data
@@ -469,106 +469,3 @@ class OpenPMDTimeSeries(parent_class):
 
         # Register the value in the object
         self.current_t = self.t[self.current_i]
-
-
-def list_h5_files(path_to_dir):
-    """
-    Return a list of the hdf5 files in this directory,
-    and a list of the corresponding iterations
-
-    Parameter
-    ---------
-    path_to_dir : string
-        The path to the directory where the hdf5 files are.
-
-    Returns
-    -------
-    A tuple with:
-    - a list of strings which correspond to the absolute path of each file
-    - a list of integers which correspond to the iteration of each file
-    """
-    # Find all the files in the provided directory
-    all_files = os.listdir(path_to_dir)
-
-    # Select the hdf5 files
-    iters_and_names = []
-    for filename in all_files:
-        # Use only the name that end with .h5 or .hdf5
-        if filename[-3:] == '.h5' or filename[-5:] == '.hdf5':
-            # Extract the iteration, using regular expressions (regex)
-            regex_match = re.search('(\d+).h[df]*5', filename)
-            if regex_match is None:
-                print('Ill-formated HDF5 file: %s\n File names should end with'
-                      ' the iteration number, followed by ".h5"' % filename)
-            else:
-                iteration = int(regex_match.groups()[-1])
-                full_name = os.path.join(
-                    os.path.abspath(path_to_dir), filename)
-                # Create list of tuples (which can be sorted together)
-                iters_and_names.append((iteration, full_name))
-
-    # Sort the list of tuples according to the iteration
-    iters_and_names.sort()
-    # Extract the list of filenames and iterations
-    filenames = [name for (it, name) in iters_and_names]
-    iterations = [it for (it, name) in iters_and_names]
-
-    return(filenames, iterations)
-
-
-def apply_selection(file_handle, data_list, select, species, extensions):
-    """
-    Select the elements of each particle quantities in data_list,
-    based on the selection rules in `select`
-
-    Parameters
-    ----------
-    file_handle: h5py.File object
-        The HDF5 file from which to extract data
-
-    data_list: list of 1darrays
-        A list of arrays with one element per macroparticle, that represent
-        different particle quantities
-
-    select: dict
-        A dictionary of rules to select the particles
-        'x' : [-4., 10.]   (Particles having x between -4 and 10 microns)
-        'ux' : [-0.1, 0.1] (Particles having ux between -0.1 and 0.1 mc)
-        'uz' : [5., None]  (Particles with uz above 5 mc)
-
-    species: string
-       Name of the species being requested
-
-    extensions: list of strings
-        The extensions that the current OpenPMDTimeSeries complies with
-
-    Returns
-    -------
-    A list of 1darrays that correspond to data_list, but were only the
-    macroparticles that meet the selection rules are kept
-    """
-    # Create the array that determines whether the particle
-    # should be selected or not.
-    Ntot = len(data_list[0])
-    select_array = np.ones(Ntot, dtype='bool')
-
-    # Loop through the selection rules, and aggregate results in select_array
-    for quantity in select.keys():
-        q = read_species_data(file_handle, species, quantity, extensions)
-        # Check lower bound
-        if select[quantity][0] is not None:
-            select_array = np.logical_and(
-                select_array,
-                q > select[quantity][0])
-        # Check upper bound
-        if select[quantity][1] is not None:
-            select_array = np.logical_and(
-                select_array,
-                q < select[quantity][1])
-
-    # Use select_array to reduce each quantity
-    for i in range(len(data_list)):
-        if len(data_list[i]) > 1:  # Do not apply selection on scalar records
-            data_list[i] = data_list[i][select_array]
-
-    return(data_list)

--- a/opmd_viewer/openpmd_timeseries/plotter.py
+++ b/opmd_viewer/openpmd_timeseries/plotter.py
@@ -39,7 +39,7 @@ class Plotter(object):
         self.t = t
         self.iterations = iterations
 
-    def hist1d(self, q1, w, quantity1, species, current_i, nbins,
+    def hist1d(self, q1, w, quantity1, species, current_i, nbins, hist_range,
                cmap='Blues', vmin=None, vmax=None, **kw):
         """
         Plot a 1D histogram of the particle quantity q1
@@ -64,8 +64,11 @@ class Plotter(object):
         current_i: int
             The index of this iteration, within the iterations list
 
-        nbins : int, optional
+        nbins : int
            Number of bins for the histograms
+
+        hist_range : list of 2 floats
+           Extent of the histogram
 
         **kw : dict, otional
            Additional options to be passed to matplotlib's hist
@@ -75,13 +78,14 @@ class Plotter(object):
         time_fs = 1.e15 * self.t[current_i]
 
         # Do the plot
-        plt.hist(q1, bins=nbins, weights=w, **kw)
+        plt.hist(q1, bins=nbins, range=hist_range, weights=w, **kw)
+        plt.xlim(hist_range)
         plt.xlabel(quantity1, fontsize=self.fontsize)
         plt.title("%s:   t =  %.0f fs    (iteration %d)"
                   % (species, time_fs, iteration), fontsize=self.fontsize)
 
     def hist2d(self, q1, q2, w, quantity1, quantity2, species, current_i,
-               nbins, cmap='Blues', vmin=None, vmax=None, **kw):
+                nbins, hist_range, cmap='Blues', vmin=None, vmax=None, **kw):
         """
         Plot a 2D histogram of the particle quantity q1
         Sets the proper labels
@@ -105,8 +109,11 @@ class Plotter(object):
         current_i: int
             The index of this iteration, within the iterations list
 
-        nbins : int, optional
-           Number of bins for the histograms
+        nbins : list of 2 ints
+           Number of bins along each direction, for the histograms
+
+        hist_range : list contains 2 lists of 2 floats
+           Extent of the histogram along each direction
 
         **kw : dict, otional
            Additional options to be passed to matplotlib's hist
@@ -116,7 +123,7 @@ class Plotter(object):
         time_fs = 1.e15 * self.t[current_i]
 
         # Do the plot
-        plt.hist2d(q1, q2, bins=nbins, cmap=cmap,
+        plt.hist2d(q1, q2, bins=nbins, cmap=cmap, range=hist_range,
                    vmin=vmin, vmax=vmax, weights=w, **kw)
         plt.colorbar()
         plt.xlabel(quantity1, fontsize=self.fontsize)

--- a/opmd_viewer/openpmd_timeseries/utilities.py
+++ b/opmd_viewer/openpmd_timeseries/utilities.py
@@ -1,0 +1,117 @@
+"""
+This file is part of the openPMD-viewer.
+
+It defines a number of helper functions that are used in main.py
+
+Copyright 2015-2016, openPMD-viewer contributors
+Authors: Remi Lehe
+License: 3-Clause-BSD-LBNL
+"""
+
+import os
+import re
+import numpy as np
+from .data_reader.particle_reader import read_species_data
+
+
+def list_h5_files(path_to_dir):
+    """
+    Return a list of the hdf5 files in this directory,
+    and a list of the corresponding iterations
+
+    Parameter
+    ---------
+    path_to_dir : string
+        The path to the directory where the hdf5 files are.
+
+    Returns
+    -------
+    A tuple with:
+    - a list of strings which correspond to the absolute path of each file
+    - a list of integers which correspond to the iteration of each file
+    """
+    # Find all the files in the provided directory
+    all_files = os.listdir(path_to_dir)
+
+    # Select the hdf5 files
+    iters_and_names = []
+    for filename in all_files:
+        # Use only the name that end with .h5 or .hdf5
+        if filename[-3:] == '.h5' or filename[-5:] == '.hdf5':
+            # Extract the iteration, using regular expressions (regex)
+            regex_match = re.search('(\d+).h[df]*5', filename)
+            if regex_match is None:
+                print('Ill-formated HDF5 file: %s\n File names should end with'
+                      ' the iteration number, followed by ".h5"' % filename)
+            else:
+                iteration = int(regex_match.groups()[-1])
+                full_name = os.path.join(
+                    os.path.abspath(path_to_dir), filename)
+                # Create list of tuples (which can be sorted together)
+                iters_and_names.append((iteration, full_name))
+
+    # Sort the list of tuples according to the iteration
+    iters_and_names.sort()
+    # Extract the list of filenames and iterations
+    filenames = [name for (it, name) in iters_and_names]
+    iterations = [it for (it, name) in iters_and_names]
+
+    return(filenames, iterations)
+
+
+def apply_selection(file_handle, data_list, select, species, extensions):
+    """
+    Select the elements of each particle quantities in data_list,
+    based on the selection rules in `select`
+
+    Parameters
+    ----------
+    file_handle: h5py.File object
+        The HDF5 file from which to extract data
+
+    data_list: list of 1darrays
+        A list of arrays with one element per macroparticle, that represent
+        different particle quantities
+
+    select: dict
+        A dictionary of rules to select the particles
+        'x' : [-4., 10.]   (Particles having x between -4 and 10 microns)
+        'ux' : [-0.1, 0.1] (Particles having ux between -0.1 and 0.1 mc)
+        'uz' : [5., None]  (Particles with uz above 5 mc)
+
+    species: string
+       Name of the species being requested
+
+    extensions: list of strings
+        The extensions that the current OpenPMDTimeSeries complies with
+
+    Returns
+    -------
+    A list of 1darrays that correspond to data_list, but were only the
+    macroparticles that meet the selection rules are kept
+    """
+    # Create the array that determines whether the particle
+    # should be selected or not.
+    Ntot = len(data_list[0])
+    select_array = np.ones(Ntot, dtype='bool')
+
+    # Loop through the selection rules, and aggregate results in select_array
+    for quantity in select.keys():
+        q = read_species_data(file_handle, species, quantity, extensions)
+        # Check lower bound
+        if select[quantity][0] is not None:
+            select_array = np.logical_and(
+                select_array,
+                q > select[quantity][0])
+        # Check upper bound
+        if select[quantity][1] is not None:
+            select_array = np.logical_and(
+                select_array,
+                q < select[quantity][1])
+
+    # Use select_array to reduce each quantity
+    for i in range(len(data_list)):
+        if len(data_list[i]) > 1:  # Do not apply selection on scalar records
+            data_list[i] = data_list[i][select_array]
+
+    return(data_list)

--- a/opmd_viewer/openpmd_timeseries/utilities.py
+++ b/opmd_viewer/openpmd_timeseries/utilities.py
@@ -115,3 +115,55 @@ def apply_selection(file_handle, data_list, select, species, extensions):
             data_list[i] = data_list[i][select_array]
 
     return(data_list)
+
+
+def fit_bins_to_grid( hist_size, grid_size, grid_range ):
+    """
+    Given a tentative number of bins `hist_size` for a histogram over
+    the range `grid_range`, return a modified number of bins `hist_size`
+    and a modified range `hist_range` so that the spacing of the histogram
+    bins is an integer multiple (or integer divisor) of the grid spacing.
+
+    Parameters:
+    ----------
+    hist_size: integer
+        The number of bins in the histogram along the considered direction
+
+    grid_size: integer
+        The number of cells in the grid
+
+    grid_range: list of floats (in meters)
+        The extent of the grid
+
+    Returns:
+    --------
+    hist_size: integer
+        The new number of bins
+
+    hist_range: list of floats (in microns)
+        The new range of the histogram
+    """
+    # The new histogram range is the same as the grid range
+    hist_range = grid_range
+
+    # Calculate histogram tentative spacing, and grid spacing
+    hist_spacing = ( hist_range[1] - hist_range[0] ) * 1. / hist_size
+    grid_spacing = ( grid_range[1] - grid_range[0] ) * 1. / grid_size
+
+    # Modify the histogram spacing, so that either:
+    if hist_spacing >= grid_spacing:
+        # - The histogram spacing is an integer multiple of the grid spacing
+        hist_spacing = int( hist_spacing / grid_spacing ) * grid_spacing
+    else:
+        # - The histogram spacing is an integer divisor of the grid spacing
+        hist_spacing = grid_spacing / int( grid_spacing / hist_spacing )
+
+    # Get the corresponding new number of bins, and the new range
+    hist_size = int( ( hist_range[1] - hist_range[0] ) / hist_spacing )
+    hist_range[1] = hist_range[0] + hist_size * hist_spacing
+
+    # Convert the range to microns (since this is how particle positions
+    # are returned in the openPMD-viewer)
+    hist_range = [ 1.e6 * hist_range[0], 1.e6 * hist_range[1] ]
+
+    return( hist_size, hist_range )


### PR DESCRIPTION
** Please merge #131 first, before reviewing this PR.** 
Merging #131 will make it easier to review this PR, as it will reduce the number of changes with the branch `dev`.

This PR adds the possibility to use information from the field mesh, in order to better choose the parameters of the histograms. More precisely, one problem with the histogram is that, **when particles are regularly-spaced (with a period related to the grid spacing)**, one gets artifacts that depend on the size of the bins of the histograms, as in the examples below:

![figure_1](https://cloud.githubusercontent.com/assets/6685781/21088230/4af7e962-bfe2-11e6-8a20-d2abfb87681a.png)
![figure_1](https://cloud.githubusercontent.com/assets/6685781/21088243/65cb4fa4-bfe2-11e6-9549-7126726dcaba.png)

With the current pull request, these figures become:
![figure_1](https://cloud.githubusercontent.com/assets/6685781/21088261/8ce916c0-bfe2-11e6-9059-8f2022c92770.png)
![figure_1](https://cloud.githubusercontent.com/assets/6685781/21088268/9b0de474-bfe2-11e6-8a86-1d2977997ad6.png)
This is done by choosing the bin size of the histograms to be a multiple of the grid size.

Thus this PR implements an optional argument `use_field_mesh` in the `get_particle` function. When this is True:
 - The extent of the histogram (along any spatial dimension) is automatically chosen to be roughly the extent of the spatial mesh.
 - The number of bins (along any spatial dimension) is slightly modified (from the value `nbins` provided by the user) so that the spacing of the histogram is an integer multiple of the grid spacing. This avoids artifacts in the plot, whenever particles are regularly spaced in each cell of the spatial mesh.

I also modified the slider, in order to have a button with this option:
<img width="374" alt="screen shot 2016-12-11 at 8 48 26 pm" src="https://cloud.githubusercontent.com/assets/6685781/21088354/320d58aa-bfe3-11e6-99ff-41c7e79daab3.png">
