### PR TITLE
Added plotting and interactive support for 1D fields

### DIFF
--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -268,7 +268,8 @@ class InteractiveViewer(object):
             if self.geometry == "thetaMode":
                 coord_button = widgets.ToggleButtons(
                     description='Coord:', options=['x', 'y', 'z', 'r', 't'])
-            elif self.geometry in ["2dcartesian", "3dcartesian"]:
+            elif self.geometry in \
+                    ["1dcartesian", "2dcartesian", "3dcartesian"]:
                 coord_button = widgets.ToggleButtons(
                     description='Coord:', options=['x', 'y', 'z'])
             coord_button.observe( refresh_field, 'value', 'change')
@@ -282,7 +283,7 @@ class InteractiveViewer(object):
             theta_button.observe( refresh_field, 'value', 'change')
             # Slicing buttons (for 3D)
             slicing_dir_button = widgets.ToggleButtons(
-                value=self.axis_labels[1], options=self.axis_labels,
+                value=self.axis_labels[0], options=self.axis_labels,
                 description='Slicing direction:')
             slicing_dir_button.observe( refresh_field, 'value', 'change' )
             slicing_button = widgets.FloatSlider(
@@ -328,7 +329,7 @@ class InteractiveViewer(object):
                 container_fields = widgets.VBox(
                     children=[fieldtype_button, coord_button,
                         mode_button, theta_button])
-            elif self.geometry == "2dcartesian":
+            elif self.geometry in ["1dcartesian", "2dcartesian"]:
                 container_fields = widgets.VBox(
                     children=[fieldtype_button, coord_button])
             elif self.geometry == "3dcartesian":
@@ -340,8 +341,13 @@ class InteractiveViewer(object):
             container_fld_magnitude = widgets.HBox(
                 children=[ fld_magnitude_button, fld_use_button])
             set_widget_dimensions( container_fld_magnitude, height=50 )
-            container_fld_plots = widgets.VBox(
-                children=[ fld_figure_button, fld_range_button,
+            if self.geometry == "1dcartesian":
+                container_fld_plots = widgets.VBox(
+                    children=[ fld_figure_button, fld_range_button,
+                    container_fld_magnitude])
+            else:
+                container_fld_plots = widgets.VBox(
+                    children=[ fld_figure_button, fld_range_button,
                     container_fld_magnitude, fld_color_button])
             set_widget_dimensions( container_fld_plots, width=260 )
             # Accordion for the field widgets

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -460,7 +460,11 @@ class OpenPMDTimeSeries(parent_class):
         if (self.geometry == "3dcartesian") and (slicing is None):
             plot = False
         if plot:
-            self.plotter.show_field(F, info, slicing_dir, m,
+            if self.geometry == "1dcartesian":
+                self.plotter.show_field_1d(F, info, field_label,
+                                    self.current_i, **kw)
+            else:
+                self.plotter.show_field_2d(F, info, slicing_dir, m,
                                     field_label, self.geometry,
                                     self.current_i, **kw)
 

--- a/opmd_viewer/openpmd_timeseries/plotter.py
+++ b/opmd_viewer/openpmd_timeseries/plotter.py
@@ -131,7 +131,45 @@ class Plotter(object):
         plt.title("%s:   t =  %.1f fs   (iteration %d)"
                   % (species, time_fs, iteration), fontsize=self.fontsize)
 
-    def show_field(self, F, info, slicing_dir, m,
+    def show_field_1d( self, F, info, field_label, current_i,
+                            vmin=None, vmax=None, **kw ):
+        """
+        Plot the given field in 1D
+
+        Parameters
+        ----------
+        F: 1darray of floats
+            Contains the field to be plotted
+
+        info: a FieldMetaInformation object
+            Contains the information about the plotted field
+
+        field_label: string
+           The name of the field plotted (for labeling purposes)
+
+        vmin, vmax: floats or None
+           The amplitude of the field
+        """
+        # Find the iteration and time
+        iteration = self.iterations[current_i]
+        time_fs = 1.e15 * self.t[current_i]
+
+        # Get the title and labels
+        plt.title("%s at %.1f fs   (iteration %d)"
+                % (field_label, time_fs, iteration), fontsize=self.fontsize)
+
+        # Add the name of the axes
+        plt.xlabel('$%s \;(\mu m)$' % info.axes[0], fontsize=self.fontsize)
+        # Get the x axis in microns
+        xaxis = 1.e6 * getattr( info, info.axes[0] )
+        # Plot the data
+        plt.plot( xaxis, F )
+        # Get the limits of the plot
+        plt.xlim( xaxis.min(), xaxis.max() )
+        if (vmin is not None) and (vmax is not None):
+            plt.ylim( vmin, vmax )
+
+    def show_field_2d(self, F, info, slicing_dir, m,
                    field_label, geometry, current_i, **kw):
         """
         Plot the given field in 2D


### PR DESCRIPTION
As a follow up to #135, I added plotting and GUI (i.e. `slider`) support for the 1D fields.

@ax3l , @macgiver2b : Since you seem to currently be working with 1D fields, could you give it a try (i.e. pull and install this branch + test the slider with your data), and check that everything works fine?

Thanks!