### PR TITLE
Close#148 Slider: Naming Slice

### DIFF
--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -284,7 +284,7 @@ class InteractiveViewer(object):
             # Slicing buttons (for 3D)
             slicing_dir_button = widgets.ToggleButtons(
                 value=self.axis_labels[0], options=self.axis_labels,
-                description='Slicing direction:')
+                description='Slice normal:')
             slicing_dir_button.observe( refresh_field, 'value', 'change' )
             slicing_button = widgets.FloatSlider(
                 description='Slicing:', min=-1., max=1., value=0.)

--- a/opmd_viewer/openpmd_timeseries/plotter.py
+++ b/opmd_viewer/openpmd_timeseries/plotter.py
@@ -214,8 +214,9 @@ class Plotter(object):
                       fontsize=self.fontsize)
         # 3D Cartesian geometry
         elif geometry == "3dcartesian":
-            plt.title("%s sliced across %s at %.1f fs  (iteration %d)"
-                      % (field_label, slicing_dir, time_fs, iteration),
+            slice_plane = info.axes[0] + '-' + info.axes[1]
+            plt.title("%s sliced in %s at %.1f fs  (iteration %d)"
+                      % (field_label, slice_plane, time_fs, iteration),
                       fontsize=self.fontsize)
 
         # Add the name of the axes


### PR DESCRIPTION
This PR uses a clearer name for slicing in the GUI. 
The title of the plots (when using slicing) have also been updated.
Here is how the new interface looks:
<img width="695" alt="screen shot 2017-03-02 at 6 32 29 am" src="https://cloud.githubusercontent.com/assets/6685781/23514332/ddd7e0b6-ff1b-11e6-810c-007368af3b0b.png">
