### PR TITLE
Python 3.4: Re-Enable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
     - os: linux
       python: "2.7"
     - os: linux
+      python: "3.4"
+    - os: linux
       python: "3.5"
     - os: linux
       python: "3.6"

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(name='openPMD-viewer',
           'Topic :: Scientific/Engineering :: Visualization',
           'Topic :: Database :: Front-Ends',
           'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: 3.6'],
       )


### PR DESCRIPTION
Related to #152: Python 3.4 was (accidentially) dropped in setup meta information (which affects PyPI shipping and version selection). Also re-enables testing for it in travis.

If there are no major problems with this release, we should support Python 3.4 (although 3.5+ added major speed improvements) because it's still the stable Python release on many distributions.