### PR TITLE
Close #156 Need normalization for zero-mass particles

### DIFF
--- a/opmd_viewer/openpmd_timeseries/data_reader/particle_reader.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/particle_reader.py
@@ -81,8 +81,11 @@ def read_species_data(file_handle, species, record_comp, extensions):
         data *= 1.e6
     # - Return momentum in normalized units
     elif record_comp in ['ux', 'uy', 'uz' ]:
-        norm_factor = 1. / (get_data(species_grp['mass']) * constants.c)
-        data *= norm_factor
+        m = get_data(species_grp['mass'])
+        # Normalize only if the particle mass is non-zero
+        if np.all( m != 0 ):
+            norm_factor = 1. / (m * constants.c)
+            data *= norm_factor
 
     # Return the data
     return(data)

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -129,11 +129,14 @@ class OpenPMDTimeSeries(parent_class):
         Extract a list of particle variables
         from an HDF5 file in the openPMD format.
 
-        In the case of positions, the result is returned in microns
-
         Plot the histogram of the returned quantity.
         If two quantities are requested by the user, this plots
         a 2d histogram of these quantities.
+
+        In the case of positions, the result is returned in microns
+        In the case of momenta, the result is returned as:
+        - unitless momentum (i.e. gamma*beta) for particles with non-zero mass
+        - in kg.m.s^-1 for particles with zero mass
 
         Parameters
         ----------


### PR DESCRIPTION
Close #156: This pull request avoids dividing the momentum by m*c in the case of particles having zero mass. Thus, for these particles, the momentum is effectively kept in SI units (kg.m.s^-1).

@n01r : Does this work for your use case? If not, please let me know how it could be improved.