### PR TITLE
Fix the releasing process for conda

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,9 +11,7 @@ PyPI and conda. In particular:
 
 - you should install the packages
 [`pypandoc`](https://pypi.python.org/pypi/pypandoc/),
-[`twine`](https://pypi.python.org/pypi/twine),
-[`conda-build`](http://conda.pydata.org/docs/commands/build/conda-build.html)
-and [`anaconda-client`](https://anaconda.org/anaconda/anaconda-client)
+[`twine`](https://pypi.python.org/pypi/twine) and [`anaconda-client`](https://anaconda.org/anaconda/anaconda-client)
 - you should have a registered account on [PyPI](https://pypi.python.org/pypi) and [test PyPI](https://testpypi.python.org/pypi), and your `$HOME` should contain a file `.pypirc` which contains the following text:
 
  ```
@@ -66,12 +64,13 @@ replace `pypi` by `pypitest` in the above set of commands)
 - `cd` into the folder `conda_recipe` and make sure that the version
   number in `meta.yaml` matches the current version.
 
-- Still in the folder `conda_recipe`, build the package for python 2.7,
-python 3.5 and python 3.6, and convert them for all available OS, by using the
-provided build script (this takes some time):
+- Still in the folder `conda_recipe`, run
 ```
-bash build.sh
+docker build -t openpmd_build .
+docker run -it -v $PWD:/home/ openpmd_build
 ```
+This builds the conda packages for Python 2.7, 3.4, 3.5 and 3.6, using a
+reproduceable environment.
 
 - Upload the different versions to Anaconda.org
 ```

--- a/conda_recipe/Dockerfile
+++ b/conda_recipe/Dockerfile
@@ -1,0 +1,19 @@
+FROM continuumio/miniconda
+
+RUN apt-get update && apt-get install -y gcc libgl1-mesa-glx
+
+RUN conda install --yes conda conda-build
+
+CMD cd /home/ \
+    && conda build --python=2.7 . \
+    && conda build --python=3.4 . \
+    && conda build --python=3.5 . \
+    && conda build --python=3.6 . \
+    && conda convert $(conda build --python=2.7 . --output) -p osx-64 \
+    && conda convert $(conda build --python=2.7 . --output) -p linux-64 \
+    && conda convert $(conda build --python=3.4 . --output) -f -p osx-64 \
+    && conda convert $(conda build --python=3.4 . --output) -f -p linux-64 \
+    && conda convert $(conda build --python=3.5 . --output) -f -p osx-64 \
+    && conda convert $(conda build --python=3.5 . --output) -f -p linux-64 \
+    && conda convert $(conda build --python=3.6 . --output) -f -p osx-64 \
+    && conda convert $(conda build --python=3.6 . --output) -f -p linux-64

--- a/conda_recipe/Dockerfile
+++ b/conda_recipe/Dockerfile
@@ -1,6 +1,11 @@
 FROM continuumio/miniconda
+MAINTAINER Remi Lehe <rlehe@lbl.gov>
 
-RUN apt-get update && apt-get install -y gcc libgl1-mesa-glx
+RUN apt-get update \
+    && apt-get install -y \
+        gcc \
+        libgl1-mesa-glx \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN conda install --yes conda conda-build
 

--- a/conda_recipe/build.sh
+++ b/conda_recipe/build.sh
@@ -1,9 +1,0 @@
-conda build --python=2.7 .
-conda build --python=3.5 .
-conda build --python=3.6 .
-conda convert $(conda build --python=2.7 . --output) -p osx-64
-conda convert $(conda build --python=2.7 . --output) -p linux-64
-conda convert $(conda build --python=3.5 . --output) -f -p osx-64
-conda convert $(conda build --python=3.5 . --output) -f -p linux-64
-conda convert $(conda build --python=3.6 . --output) -f -p osx-64
-conda convert $(conda build --python=3.6 . --output) -f -p linux-64


### PR DESCRIPTION
When creating a new release of `openPMD-viewer`, we upload the package so that it can be installed with `pip`, as well as with `conda`.

In the case of `conda`, this requires `conda build`. However, recently I experienced issues with `conda build`ing openPMD-viewer on Mac OSX (which is the OS on which I typically create the package). As a consequence, this pull request provides tools to create the openPMD-viewer conda package **inside a Docker container**. (The Docker container is a virtual linux environment, and thus it does not have the above mentioned problem of Mac.)

More precisely:
- I modified RELEASING.md which gives instructions on how to build the package.
- I replaced `build.sh` (which automated the process of creating openPMD-viewer packages for python 2.7, 3.4, 3.5, 3.6) by a corresponding Dockerfile.