### PR TITLE
Close #160 Setting plot range for fields causes error

### DIFF
--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -77,8 +77,8 @@ class InteractiveViewer(object):
 
                 if fld_use_button.value:
                     i_power = fld_magnitude_button.value
-                    vmin = fld_range_button.value[0] * 10 ** i_power
-                    vmax = fld_range_button.value[1] * 10 ** i_power
+                    vmin = fld_range_button.value[0] * 10. ** i_power
+                    vmax = fld_range_button.value[1] * 10. ** i_power
                 else:
                     vmin = None
                     vmax = None
@@ -123,8 +123,8 @@ class InteractiveViewer(object):
 
                 if ptcl_use_button.value:
                     i_power = ptcl_magnitude_button.value
-                    vmin = ptcl_range_button.value[0] * 10 ** i_power
-                    vmax = ptcl_range_button.value[1] * 10 ** i_power
+                    vmin = ptcl_range_button.value[0] * 10. ** i_power
+                    vmax = ptcl_range_button.value[1] * 10. ** i_power
                 else:
                     vmin = None
                     vmax = None


### PR DESCRIPTION
As mentioned in the corresponding issue, the reported problem was due to Python storing `vmin` and `vmax` as integers (and thus encountering an overflow for large values). 

The synthax changes of this PR force `vmin` and `vmax` to be float, and fixes the issue.