### PR TITLE
Change the default figure size and font size

### DIFF
--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -23,7 +23,7 @@ class InteractiveViewer(object):
     def __init__(self):
         pass
 
-    def slider(self, figsize=(8, 8),
+    def slider(self, figsize=(6, 5),
                exclude_particle_records=['charge', 'mass'], **kw):
         """
         Navigate the simulation using a slider

--- a/opmd_viewer/openpmd_timeseries/plotter.py
+++ b/opmd_viewer/openpmd_timeseries/plotter.py
@@ -32,7 +32,7 @@ class Plotter(object):
            Iteration number for each available iteration of the timeseries
         """
         # Default fontsize
-        self.fontsize = 18
+        self.fontsize = 12
 
         # Register the time array and iterations array
         # (Useful when labeling the figures)


### PR DESCRIPTION
The default figure size of openPMD-viewer made it difficult to work on a laptop (because the figure were too big.) In addition, the font size was to big and thus the labels were often colliding with other parts of the figure.

The current pull request fixes those 2 issues. Here is a screenshot with the new sizes, on a laptop.
<img width="1279" alt="screen shot 2017-07-17 at 10 03 40 pm" src="https://user-images.githubusercontent.com/6685781/28301496-d4c6ec74-6b3b-11e7-893b-c8279700249c.png">
