### PR TITLE
Replace the time slider by an iteration slider

### DIFF
--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -153,8 +153,8 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             i += 1
         # Plot the result if needed
         if plot:
-            iteration = self.iterations[ self.current_i ]
-            time_fs = 1.e15 * self.t[ self.current_i ]
+            iteration = self.iterations[ self._current_i ]
+            time_fs = 1.e15 * self.t[ self._current_i ]
             plt.plot( z_pos, spreads, **kw)
             plt.title("Slice energy spread at %.1f fs   (iteration %d)"
                 % (time_fs, iteration ), fontsize=self.plotter.fontsize)
@@ -354,8 +354,8 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             global_offset=(np.min(z) + len_z / bins / 2,), position=(0,))
         # Plot the result if needed
         if plot:
-            iteration = self.iterations[ self.current_i ]
-            time_fs = 1.e15 * self.t[ self.current_i ]
+            iteration = self.iterations[ self._current_i ]
+            time_fs = 1.e15 * self.t[ self._current_i ]
             plt.plot( info.z, current, **kw)
             plt.title("Current at %.1f fs   (iteration %d)"
                 % (time_fs, iteration ), fontsize=self.plotter.fontsize)
@@ -449,8 +449,8 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
 
         # Plot the result if needed
         if plot:
-            iteration = self.iterations[ self.current_i ]
-            time_fs = 1.e15 * self.t[ self.current_i ]
+            iteration = self.iterations[ self._current_i ]
+            time_fs = 1.e15 * self.t[ self._current_i ]
             if index != 'all':
                 plt.plot( 1.e6 * info.z, envelope, **kw)
                 plt.ylabel('$E_%s \;(V/m)$' % pol,
@@ -631,8 +631,8 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
 
         # Plot the field if required
         if plot:
-            iteration = self.iterations[ self.current_i ]
-            time_fs = 1.e15 * self.t[ self.current_i ]
+            iteration = self.iterations[ self._current_i ]
+            time_fs = 1.e15 * self.t[ self._current_i ]
             plt.plot( spect_info.omega, spectrum, **kw )
             plt.xlabel('$\omega \; (rad.s^{-1})$',
                        fontsize=self.plotter.fontsize )
@@ -894,8 +894,8 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
 
         # Plot the result if needed
         if plot:
-            iteration = self.iterations[ self.current_i ]
-            time_fs = 1.e15 * self.t[ self.current_i ]
+            iteration = self.iterations[ self._current_i ]
+            time_fs = 1.e15 * self.t[ self._current_i ]
             plt.imshow( spectrogram, extent=info.imshow_extent, aspect='auto',
                         **kw)
             plt.title("Spectrogram at %.1f fs   (iteration %d)"

--- a/opmd_viewer/openpmd_timeseries/utilities.py
+++ b/opmd_viewer/openpmd_timeseries/utilities.py
@@ -28,7 +28,7 @@ def list_h5_files(path_to_dir):
     -------
     A tuple with:
     - a list of strings which correspond to the absolute path of each file
-    - a list of integers which correspond to the iteration of each file
+    - an array of integers which correspond to the iteration of each file
     """
     # Find all the files in the provided directory
     all_files = os.listdir(path_to_dir)
@@ -53,7 +53,7 @@ def list_h5_files(path_to_dir):
     iters_and_names.sort()
     # Extract the list of filenames and iterations
     filenames = [name for (it, name) in iters_and_names]
-    iterations = [it for (it, name) in iters_and_names]
+    iterations = np.array([it for (it, name) in iters_and_names])
 
     return(filenames, iterations)
 


### PR DESCRIPTION
The previous time slider (which printed the time in femtosecond) was not very useful in practice. It turns out that it is usually more intuitive to think of the simulation outputs in terms of iteration number (of the PIC loop).

Therefore, this pull request replaces the time slider by an iteration slider.

In addition, it renames a few variables, as dicussed with @ax3l in issue #130:
- `self.current_i` is replaced by `self._current_i` so that user do not attempt to use it
- `self.current_iteration` was created.
In order to make this easy, the set of iterations of the simulations is now a numpy array (it used to be a list).