### PR TITLE
Set plot range for field plotter

### DIFF
--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -507,7 +507,17 @@ class RangeSelector(object):
 
     def __init__( self, callback_function, default_value, title ):
         """
-        # TODO
+        Initialize a set of widgets that select a range of (float) values
+
+        Parameters:
+        -----------
+        callback_function: callable
+            The function to call when activating/deactivating the range
+        default_value:
+            The default value of the upper bound of the range at initialization
+            (The default lower bound is the opposite of this value.)
+        title:
+            The title that is displayed on top of the widgets
         """
         # Register title
         self.title = title
@@ -523,7 +533,8 @@ class RangeSelector(object):
 
     def to_container( self ):
         """
-        # TODO
+        Return a widget container, where all the range widgets
+        are placed properly, with respect to each other.
         """
         # Set the widget dimensions
         set_widget_dimensions( self.active, width=20 )
@@ -541,7 +552,8 @@ class RangeSelector(object):
 
     def get_range( self ):
         """
-        # TODO
+        Return a list of 2 elements: the current lower bound and upper bound.
+        When the widget is not active, None is returned instead of the bounds.
         """
         if self.active.value is True:
             return( [ self.low_bound.value, self.up_bound.value ] )

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -333,7 +333,8 @@ class OpenPMDTimeSeries(parent_class):
 
     def get_field(self, field=None, coord=None, t=None, iteration=None,
                   m='all', theta=0., slicing=0., slicing_dir='y',
-                  output=True, plot=False, **kw):
+                  output=True, plot=False,
+                  plot_range=[[None, None], [None, None]], **kw):
         """
         Extract a given field from an HDF5 file in the openPMD format.
 
@@ -385,6 +386,12 @@ class OpenPMDTimeSeries(parent_class):
 
         plot : bool, optional
            Whether to plot the requested quantity
+
+        plot_range : list of lists
+           A list containing 2 lists of 2 elements each
+           Indicates the values between which to clip the plot,
+           along the 1st axis (first list) and 2nd axis (second list)
+           Default: plots the full extent of the simulation box
 
         **kw : dict, otional
            Additional options to be passed to matplotlib's imshow.
@@ -475,11 +482,11 @@ class OpenPMDTimeSeries(parent_class):
         if plot:
             if self.geometry == "1dcartesian":
                 self.plotter.show_field_1d(F, info, field_label,
-                                    self._current_i, **kw)
+                self._current_i, plot_range=plot_range, **kw)
             else:
                 self.plotter.show_field_2d(F, info, slicing_dir, m,
-                                    field_label, self.geometry,
-                                    self._current_i, **kw)
+                        field_label, self.geometry, self._current_i,
+                        plot_range=plot_range, **kw)
 
         # Return the result
         return(F, info)

--- a/opmd_viewer/openpmd_timeseries/plotter.py
+++ b/opmd_viewer/openpmd_timeseries/plotter.py
@@ -131,7 +131,7 @@ class Plotter(object):
         plt.title("%s:   t =  %.1f fs   (iteration %d)"
                   % (species, time_fs, iteration), fontsize=self.fontsize)
 
-    def show_field_1d( self, F, info, field_label, current_i,
+    def show_field_1d( self, F, info, field_label, current_i, plot_range,
                             vmin=None, vmax=None, **kw ):
         """
         Plot the given field in 1D
@@ -149,6 +149,10 @@ class Plotter(object):
 
         vmin, vmax: floats or None
            The amplitude of the field
+
+        plot_range : list of lists
+           Indicates the values between which to clip the plot,
+           along the 1st axis (first list) and 2nd axis (second list)
         """
         # Find the iteration and time
         iteration = self.iterations[current_i]
@@ -165,12 +169,17 @@ class Plotter(object):
         # Plot the data
         plt.plot( xaxis, F )
         # Get the limits of the plot
-        plt.xlim( xaxis.min(), xaxis.max() )
-        if (vmin is not None) and (vmax is not None):
-            plt.ylim( vmin, vmax )
+        # - Along the first dimension
+        if (plot_range[0][0] is not None) and (plot_range[0][1] is not None):
+            plt.xlim( plot_range[0][0], plot_range[0][1] )
+        else:
+            plt.xlim( xaxis.min(), xaxis.max() )  # Full extent of the box
+        # - Along the second dimension
+        if (plot_range[1][0] is not None) and (plot_range[1][1] is not None):
+            plt.ylim( plot_range[1][0], plot_range[1][1] )
 
-    def show_field_2d(self, F, info, slicing_dir, m,
-                   field_label, geometry, current_i, **kw):
+    def show_field_2d(self, F, info, slicing_dir, m, field_label, geometry,
+                        current_i, plot_range, **kw):
         """
         Plot the given field in 2D
 
@@ -195,6 +204,10 @@ class Plotter(object):
 
         geometry: string
            Either "2dcartesian", "3dcartesian" or "thetaMode"
+
+        plot_range : list of lists
+           Indicates the values between which to clip the plot,
+           along the 1st axis (first list) and 2nd axis (second list)
         """
         # Find the iteration and time
         iteration = self.iterations[current_i]
@@ -227,3 +240,11 @@ class Plotter(object):
         plt.imshow(F, extent=1.e6 * info.imshow_extent, origin='lower',
                    interpolation='nearest', aspect='auto', **kw)
         plt.colorbar()
+
+        # Get the limits of the plot
+        # - Along the first dimension
+        if (plot_range[0][0] is not None) and (plot_range[0][1] is not None):
+            plt.xlim( plot_range[0][0], plot_range[0][1] )
+        # - Along the second dimension
+        if (plot_range[1][0] is not None) and (plot_range[1][1] is not None):
+            plt.ylim( plot_range[1][0], plot_range[1][1] )


### PR DESCRIPTION
This pull request is the first of a series of 3 pull request that (in my opinion at least) improve the openPMD-viewer GUI.

The current pull request adds the possibility for the user to enter a range of values, in order to clip the plot of the fields. Here is how it looks
<img width="404" alt="screen shot 2017-07-18 at 7 53 51 am" src="https://user-images.githubusercontent.com/6685781/28323665-51b640e8-6b8e-11e7-87a3-99136f8a7b28.png">

If "Use this range" is not used, then the full range of the box (along this axis) is plotted. 

Note: For now, this does not implement the solution proposed in #140. This is in part because, when using `%matplotlib inline`, the user is unable to interactively zoom, and therefore needs a separate widget.