### PR TITLE
Better color widgets

### DIFF
--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -123,7 +123,7 @@ class InteractiveViewer(object):
                     clear_output()
 
                 # Colorscale range
-                vmin, vmax = fld_color_button.get_range()
+                vmin, vmax = ptcl_color_button.get_range()
 
                 if ptcl_yaxis_button.value == 'None':
                     # 1D histogram

--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -463,17 +463,14 @@ class ColorBarSelector(object):
         """
         Initialize a set of widgets that select a colorbar.
 
-        # TODO
-
         Parameters:
         -----------
         callback_function: callable
-            The function to call when activating/deactivating the range
-        default_value:
-            The default value of the upper bound of the range at initialization
-            (The default lower bound is the opposite of this value.)
-        title:
-            The title that is displayed on top of the widgets
+            The function to call when activating/deactivating the range,
+            or when changing the colormap
+        default_cmap: string
+            The name of the colormap that will be used when the widget is
+            initialized
         """
         # Create the colormap widget
         available_cmaps = sorted( plt.colormaps() )


### PR DESCRIPTION
**Wait for PR #165 to be merged before reviewing**

The widget for the colorbar (with the double slider to pick min/max values) was quite cumbersome in practice (in part because it was small and imprecise). I replaced it by a set of text widget, which look like this:

<img width="379" alt="screen shot 2017-07-18 at 8 12 09 am" src="https://user-images.githubusercontent.com/6685781/28324689-d4b0bcce-6b90-11e7-9060-68288b7a10f9.png">

Also, the code for the colorbar widget has been refactored and is now more concise and cleaner.