### PR TITLE
Set plot range for the particle plotter

### DIFF
--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -427,8 +427,8 @@ class InteractiveViewer(object):
             container_ptcl_hrange = ptcl_hrange_button.to_container()
             container_ptcl_vrange = ptcl_vrange_button.to_container()
             container_ptcl_plots = widgets.VBox( children=[ container_ptcl_fig,
-                container_ptcl_cbar, container_ptcl_hrange,
-                container_ptcl_vrange, ptcl_use_field_button ])
+                container_ptcl_cbar, container_ptcl_vrange,
+                container_ptcl_hrange, ptcl_use_field_button ])
             set_widget_dimensions( container_ptcl_plots, width=310 )
             # Accordion for the field widgets
             accord2 = widgets.Accordion(

--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -137,7 +137,7 @@ class InteractiveViewer(object):
                         vmin=vmin, vmax=vmax,
                         cmap=ptcl_color_button.cmap.value,
                         nbins=ptcl_bins_button.value,
-                        plot_range=plot_range
+                        plot_range=plot_range,
                         use_field_mesh=ptcl_use_field_button.value )
                 else:
                     # 2D histogram
@@ -149,6 +149,7 @@ class InteractiveViewer(object):
                         vmin=vmin, vmax=vmax,
                         cmap=ptcl_color_button.cmap.value,
                         nbins=ptcl_bins_button.value,
+                        plot_range=plot_range,
                         use_field_mesh=ptcl_use_field_button.value )
 
         def refresh_field_type(change):
@@ -331,16 +332,17 @@ class InteractiveViewer(object):
             set_widget_dimensions( container_fields, width=330 )
             # Plotting options container
             container_fld_cbar = fld_color_button.to_container()
-            container_hrange = fld_hrange_button.to_container()
-            container_vrange = fld_vrange_button.to_container()
+            container_fld_hrange = fld_hrange_button.to_container()
+            container_fld_vrange = fld_vrange_button.to_container()
             if self.geometry == "1dcartesian":
                 container_fld_plots = widgets.VBox( children=[
-                    add_description("Figure:", fld_figure_button),
-                    container_vrange, container_hrange ])
+                    add_description("<b>Figure:</b>", fld_figure_button),
+                    container_fld_vrange, container_fld_hrange ])
             else:
                 container_fld_plots = widgets.VBox( children=[
-                    add_description("Figure:", fld_figure_button),
-                    container_fld_cbar, container_vrange, container_hrange ])
+                    add_description("<b>Figure:</b>", fld_figure_button),
+                    container_fld_cbar, container_fld_vrange,
+                    container_fld_hrange ])
             set_widget_dimensions( container_fld_plots, width=330 )
             # Accordion for the field widgets
             accord1 = widgets.Accordion(
@@ -418,13 +420,15 @@ class InteractiveViewer(object):
             # Particle selection container
             container_ptcl_select = ptcl_select_widget.to_container()
             # Plotting options container
-            container_ptcl_bins = widgets.HBox( children=[
-                add_description( "nbins:", ptcl_bins_button ),
-                ptcl_use_field_button ] )
+            container_ptcl_fig = widgets.HBox( children=[
+                add_description("<b>Figure:</b>", ptcl_figure_button),
+                add_description( "Bins:", ptcl_bins_button ) ] )
             container_ptcl_cbar = ptcl_color_button.to_container()
-            container_ptcl_plots = widgets.VBox( children=[
-                add_description("Figure:", ptcl_figure_button),
-                container_ptcl_bins, container_ptcl_cbar ])
+            container_ptcl_hrange = ptcl_hrange_button.to_container()
+            container_ptcl_vrange = ptcl_vrange_button.to_container()
+            container_ptcl_plots = widgets.VBox( children=[ container_ptcl_fig,
+                container_ptcl_cbar, container_ptcl_hrange,
+                container_ptcl_vrange, ptcl_use_field_button ])
             set_widget_dimensions( container_ptcl_plots, width=310 )
             # Accordion for the field widgets
             accord2 = widgets.Accordion(

--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -124,6 +124,9 @@ class InteractiveViewer(object):
 
                 # Colorscale range
                 vmin, vmax = ptcl_color_button.get_range()
+                # Determine range of the plot from widgets
+                plot_range = [ ptcl_hrange_button.get_range(),
+                                ptcl_vrange_button.get_range() ]
 
                 if ptcl_yaxis_button.value == 'None':
                     # 1D histogram
@@ -134,6 +137,7 @@ class InteractiveViewer(object):
                         vmin=vmin, vmax=vmax,
                         cmap=ptcl_color_button.cmap.value,
                         nbins=ptcl_bins_button.value,
+                        plot_range=plot_range
                         use_field_mesh=ptcl_use_field_button.value )
                 else:
                     # 2D histogram
@@ -389,10 +393,14 @@ class InteractiveViewer(object):
             # Colormap button
             ptcl_color_button = ColorBarSelector(
                 refresh_ptcl, default_cmap='Blues' )
+            # Range buttons
+            ptcl_hrange_button = RangeSelector( refresh_ptcl,
+                default_value=10., title='Horizontal axis:')
+            ptcl_vrange_button = RangeSelector( refresh_ptcl,
+                default_value=10., title='Vertical axis:')
             # Use field mesh buttons
-            ptcl_use_field_button = widgets.Checkbox(
-                description=' Use field mesh', value=True)
-            set_widget_dimensions( ptcl_use_field_button, left_margin=100 )
+            ptcl_use_field_button = widgets.ToggleButton(
+                description=' Use field mesh', value=True )
             ptcl_use_field_button.observe( refresh_ptcl, 'value', 'change')
             # Resfresh buttons
             ptcl_refresh_toggle = widgets.ToggleButton(

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -123,9 +123,10 @@ class OpenPMDTimeSeries(parent_class):
         # - Initialize a plotter object, which holds information about the time
         self.plotter = Plotter(self.t, self.iterations)
 
-    def get_particle(self, var_list=None, species=None, t=None,
-        iteration=None, select=None, output=True, plot=False, nbins=150,
-        plot_range=[[None, None], [None, None]], use_field_mesh=True, **kw):
+    def get_particle(self, var_list=None, species=None, t=None, iteration=None,
+            select=None, output=True, plot=False, nbins=150,
+            plot_range=[[None, None], [None, None]],
+            use_field_mesh=True, **kw):
         """
         Extract a list of particle variables
         from an HDF5 file in the openPMD format.
@@ -324,7 +325,7 @@ class OpenPMDTimeSeries(parent_class):
                         # Check that the user indeed allowed this dimension
                         # to be determined automatically
                         if (plot_range[i_var][0] is None) or \
-                            (plot_range[i_var][1] is None):
+                                (plot_range[i_var][1] is None):
                             hist_bins[i_var], hist_range[i_var] = \
                                 fit_bins_to_grid(hist_bins[i_var],
                                 grid_size_dict[var], grid_range_dict[var] )

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -310,7 +310,7 @@ class OpenPMDTimeSeries(parent_class):
                     hist_range.append( [ data.min(), data.max() ] )
                 else:
                     hist_range.append( [ -1., 1. ] )
-            hist_bins = [ nbins for data in data_list ]
+            hist_bins = [ nbins for i_data in range(len(data_list)) ]
             # - Then, if required by the user, modify this values by
             #   fitting them to the spatial grid
             if use_field_mesh and self.avail_fields is not None:

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -298,7 +298,7 @@ class OpenPMDTimeSeries(parent_class):
             # Determine the size of the histogram bins
             # - First pick default values
             hist_range = []
-            for i_data in len(data_list):
+            for i_data in range(len(data_list)):
                 data = data_list[i_data]
                 # Check if the user specified a value
                 if (plot_range[i_data][0] is not None) and \
@@ -323,8 +323,8 @@ class OpenPMDTimeSeries(parent_class):
                     if var in grid_size_dict.keys():
                         # Check that the user indeed allowed this dimension
                         # to be determined automatically
-                        if (plot_range[i_data][0] is None) or \
-                            (plot_range[i_data][1] is None):
+                        if (plot_range[i_var][0] is None) or \
+                            (plot_range[i_var][1] is None):
                             hist_bins[i_var], hist_range[i_var] = \
                                 fit_bins_to_grid(hist_bins[i_var],
                                 grid_size_dict[var], grid_range_dict[var] )

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -124,8 +124,8 @@ class OpenPMDTimeSeries(parent_class):
         self.plotter = Plotter(self.t, self.iterations)
 
     def get_particle(self, var_list=None, species=None, t=None,
-                     iteration=None, select=None, output=True,
-                     plot=False, nbins=150, use_field_mesh=True, **kw):
+        iteration=None, select=None, output=True, plot=False, nbins=150,
+        plot_range=[[None, None], [None, None]], use_field_mesh=True, **kw):
         """
         Extract a list of particle variables
         from an HDF5 file in the openPMD format.
@@ -176,6 +176,12 @@ class OpenPMDTimeSeries(parent_class):
         nbins : int, optional
            (Only used when `plot` is True)
            Number of bins for the histograms
+
+        plot_range : list of lists
+           A list containing 2 lists of 2 elements each
+           Indicates the values between which to perform the histogram,
+           along the 1st axis (first list) and 2nd axis (second list)
+           Default: the range is automatically determined
 
         use_field_mesh: bool, optional
            (Only used when `plot` is True)
@@ -292,8 +298,14 @@ class OpenPMDTimeSeries(parent_class):
             # Determine the size of the histogram bins
             # - First pick default values
             hist_range = []
-            for data in data_list:
-                if len(data) != 0:
+            for i_data in len(data_list):
+                data = data_list[i_data]
+                # Check if the user specified a value
+                if (plot_range[i_data][0] is not None) and \
+                        (plot_range[i_data][1] is not None):
+                    hist_range.append( plot_range[i_data] )
+                # Else use min and max of data
+                elif len(data) != 0:
                     hist_range.append( [ data.min(), data.max() ] )
                 else:
                     hist_range.append( [ -1., 1. ] )
@@ -309,9 +321,13 @@ class OpenPMDTimeSeries(parent_class):
                 for i_var in range(len(var_list)):
                     var = var_list[i_var]
                     if var in grid_size_dict.keys():
-                        hist_bins[i_var], hist_range[i_var] = \
-                            fit_bins_to_grid(hist_bins[i_var],
-                            grid_size_dict[var], grid_range_dict[var] )
+                        # Check that the user indeed allowed this dimension
+                        # to be determined automatically
+                        if (plot_range[i_data][0] is None) or \
+                            (plot_range[i_data][1] is None):
+                            hist_bins[i_var], hist_range[i_var] = \
+                                fit_bins_to_grid(hist_bins[i_var],
+                                grid_size_dict[var], grid_range_dict[var] )
 
             # - In the case of only one quantity
             if len(data_list) == 1:


### PR DESCRIPTION
**Please merge #166 first before reviewing this pull request**

This PR is similar to PR #165. This allows the user to optionally impose the range between which the particle histograms are being performed. This particularly useful e.g. when plotting the phase space in LWFA, since in this case the longitudinal phase space is extremely elongated (along the momentum axis), and having a good binning resolution would require a very large number of bins if the user were to plot the **full range**.

Here is how it looks:
<img width="386" alt="screen shot 2017-07-18 at 8 03 47 am" src="https://user-images.githubusercontent.com/6685781/28324249-aebdcc38-6b8f-11e7-8e1d-3a492c4f9f58.png">
If "Use this range" is not checked for a given direction, then openPMD-viewer check whether "Use field mesh" is checked. If yes it will use the size of the field mesh. Otherwise it will just determine the range from the min/max of the particle arrays.
