### PR TITLE
Correct widget dimensions for compatibility with ipywidgets version 4, 5 and 6

### DIFF
--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -509,33 +509,21 @@ class ColorBarSelector(object):
         """
         # Set the widget dimensions
         set_widget_dimensions( self.active, width=20 )
-        if ipywidgets_version >= 5:
-            text_width=30
-        else:
-            text_width=60
-        set_widget_dimensions( self.low_bound, width=text_width )
-        set_widget_dimensions( self.up_bound, width=text_width )
+        set_widget_dimensions( self.low_bound, width=60 )
+        set_widget_dimensions( self.up_bound, width=60 )
         set_widget_dimensions( self.exponent, width=45 )
+        set_widget_dimensions( self.cmap, width=200 )
         # Gather the different widgets on two lines
         cmap_container = widgets.VBox( children=[
             widgets.HTML( "<b>Colorbar:</b>"), self.cmap ] )
-        if ipywidgets_version >= 5:
-            range_container = widgets.HBox( children=[
-                add_description("from", self.low_bound, width=30 ),
-                add_description("to", self.up_bound, width=20 ),
-                add_description("x 10^", self.exponent, width=45),
-                self.active ] )
-            final_container = widgets.VBox(
-                children=[ cmap_container, range_container ] )
-        else:
-            range_container1 = widgets.HBox( children=[
-                add_description("from", self.low_bound, width=30 ),
-                add_description("to", self.up_bound, width=20 ) ] )
-            range_container2 = widgets.HBox( children=[
-                add_description("x 10^", self.exponent, width=45),
-                self.active ] )
-            final_container = widgets.VBox(
-                children=[cmap_container, range_container1, range_container2])
+        range_container1 = widgets.HBox( children=[
+            add_description("from", self.low_bound, width=30 ),
+            add_description("to", self.up_bound, width=20 ) ] )
+        range_container2 = widgets.HBox( children=[
+            add_description("x 10^", self.exponent, width=45),
+            self.active ] )
+        final_container = widgets.VBox(
+            children=[cmap_container, range_container1, range_container2])
         set_widget_dimensions( final_container, width=310 )
         return( final_container )
 

--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -513,13 +513,24 @@ class ColorBarSelector(object):
         set_widget_dimensions( self.exponent, width=45 )
         set_widget_dimensions( self.cmap, width=200 )
         # Gather the different widgets on two lines
-        range_container = widgets.HBox( children=[ self.active,
-            add_description(" from: ", self.low_bound, width=30 ),
-            add_description(" to: ", self.up_bound, width=20 ),
-            add_description("x 10^", self.exponent, width=45 ) ] )
-        final_container = widgets.VBox(
-            children=[ widgets.HTML( "<b>Colorbar:</b>"),
-                        self.cmap, range_container ])
+        cmap_container = widgets.HBox( children=[
+            widgets.HTML( "<b>Colorbar:</b>"), self.cmap ])
+        if ipywidgets_version > 4:
+            # For newer version of ipywidgets: add the "x10^" on same line
+            range_container = widgets.HBox( children=[ self.active,
+                add_description("from", self.low_bound, width=30 ),
+                add_description("to", self.up_bound, width=20 ),
+                add_description("x 10^", self.exponent, width=45 ) ] )
+            final_container = widgets.VBox(
+                children=[ cmap_container, range_container ])
+        else:
+            # For older version of ipywidgets: add the "x10^" on new line
+            range_container = widgets.HBox( children=[ self.active,
+                add_description("from", self.low_bound, width=30 ),
+                add_description("to", self.up_bound, width=20 ) ] )
+            final_container = widgets.VBox(
+                children=[ cmap_container, range_container,
+                add_description("x 10^", self.exponent, width=45 ) ])
         set_widget_dimensions( final_container, width=310 )
         return( final_container )
 

--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -491,8 +491,7 @@ class ColorBarSelector(object):
         self.cmap = widgets.Select(options=available_cmaps, value=default_cmap)
 
         # Create the widgets for the range
-        self.active = widgets.Checkbox(
-            description=' Use this range', value=False)
+        self.active = widgets.Checkbox( value=False )
         self.low_bound = widgets.FloatText( value=-5. )
         self.up_bound = widgets.FloatText( value=5. )
         self.exponent = widgets.FloatText( value=9. )
@@ -514,16 +513,13 @@ class ColorBarSelector(object):
         set_widget_dimensions( self.exponent, width=45 )
         set_widget_dimensions( self.cmap, width=200 )
         # Gather the different widgets on two lines
-        cmap_container = widgets.VBox( children=[
-            widgets.HTML( "<b>Colorbar:</b>"), self.cmap ] )
-        range_container1 = widgets.HBox( children=[
-            add_description("from", self.low_bound, width=30 ),
-            add_description("to", self.up_bound, width=20 ) ] )
-        range_container2 = widgets.HBox( children=[
-            add_description("x 10^", self.exponent, width=45),
-            self.active ] )
+        range_container = widgets.HBox( children=[ self.active,
+            add_description(" from: ", self.low_bound, width=30 ),
+            add_description(" to: ", self.up_bound, width=20 ),
+            add_description("x 10^", self.exponent, width=45 ) ] )
         final_container = widgets.VBox(
-            children=[cmap_container, range_container1, range_container2])
+            children=[ widgets.HTML( "<b>Colorbar:</b>"),
+                        self.cmap, range_container ])
         set_widget_dimensions( final_container, width=310 )
         return( final_container )
 
@@ -562,8 +558,7 @@ class RangeSelector(object):
         self.title = title
 
         # Create the widgets
-        self.active = widgets.Checkbox(
-            description=' Use this range', value=False)
+        self.active = widgets.Checkbox( value=False )
         self.low_bound = widgets.FloatText( value=-default_value )
         self.up_bound = widgets.FloatText( value=default_value )
 
@@ -580,9 +575,9 @@ class RangeSelector(object):
         set_widget_dimensions( self.low_bound, width=60 )
         set_widget_dimensions( self.up_bound, width=60 )
         # Gather the different widgets on one line
-        container = widgets.HBox( children=[
+        container = widgets.HBox( children=[ self.active,
             add_description("from", self.low_bound, width=30 ),
-            add_description("to", self.up_bound, width=20 ), self.active ] )
+            add_description("to", self.up_bound, width=20 ) ] )
         set_widget_dimensions( container, width=310 )
         # Add the title
         final_container = widgets.VBox( children=[

--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -509,19 +509,33 @@ class ColorBarSelector(object):
         """
         # Set the widget dimensions
         set_widget_dimensions( self.active, width=20 )
-        set_widget_dimensions( self.low_bound, width=30 )
-        set_widget_dimensions( self.up_bound, width=30 )
+        if ipywidgets_version >= 5:
+            text_width=30
+        else:
+            text_width=60
+        set_widget_dimensions( self.low_bound, width=text_width )
+        set_widget_dimensions( self.up_bound, width=text_width )
         set_widget_dimensions( self.exponent, width=45 )
         # Gather the different widgets on two lines
         cmap_container = widgets.VBox( children=[
             widgets.HTML( "<b>Colorbar:</b>"), self.cmap ] )
-        range_container = widgets.HBox( children=[
-            add_description("from", self.low_bound, width=30 ),
-            add_description("to", self.up_bound, width=20 ),
-            add_description("x 10^", self.exponent, width=45), self.active ] )
-        # Stack the two types of widgets
-        final_container = widgets.VBox(
-            children=[ cmap_container, range_container ] )
+        if ipywidgets_version >= 5:
+            range_container = widgets.HBox( children=[
+                add_description("from", self.low_bound, width=30 ),
+                add_description("to", self.up_bound, width=20 ),
+                add_description("x 10^", self.exponent, width=45),
+                self.active ] )
+            final_container = widgets.VBox(
+                children=[ cmap_container, range_container ] )
+        else:
+            range_container1 = widgets.HBox( children=[
+                add_description("from", self.low_bound, width=30 ),
+                add_description("to", self.up_bound, width=20 ) ] )
+            range_container2 = widgets.HBox( children=[
+                add_description("x 10^", self.exponent, width=45),
+                self.active ] )
+            final_container = widgets.VBox(
+                children=[cmap_container, range_container1, range_container2])
         set_widget_dimensions( final_container, width=310 )
         return( final_container )
 


### PR DESCRIPTION
Because ipywidgets version 4, 5 and 6 layout the widgets in different manners, I had to tweak the position and size of widgets in the "Plotting options" section, so that they fit inside the panels with all the versions. 

In particular, this involved removing the label "Use this range", as well as putting the widget "x10^" on a new line for ipywidgets 4. 

Here is how the widgets look with:

- ipywidgets 6 (quite neat)
![ipywidgets_6](https://user-images.githubusercontent.com/6685781/30124680-caf8876c-92ea-11e7-9455-b341f47495bf.png)

- ipywidgets 5
![ipywidgets_5](https://user-images.githubusercontent.com/6685781/30124684-cff21e40-92ea-11e7-92a0-a4cb3beae0b5.png)

- ipywidgets 4 (the extra spacing between widgets is unwanted, but cannot be fixed easily: https://github.com/jupyter-widgets/ipywidgets/issues/709)
![ipywidgets_4](https://user-images.githubusercontent.com/6685781/30124742-015dee00-92eb-11e7-9a09-29f619b9bf3b.png)

