### PR TITLE
Prevent failure of emittance calculation for empty arrays

### DIFF
--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -68,13 +68,11 @@ def clean_ipython_features(script_name):
 
         # Replace the lines that activate matplotlib in a notebook
         # by a line that selects the PS backend
-        if re.match("[ ]*get_ipython\(\)\.magic\((.*)'matplotlib",
-                    lines[i]) is not None:
+        if re.search("get_ipython.*matplotlib", lines[i]) is not None:
             lines[i] = "import matplotlib; matplotlib.use('ps')\n"
 
         # Discard the lines that use in-notebook documentation
-        if re.match("[ ]*get_ipython\(\)\.magic\((.*)'pinfo",
-                    lines[i]) is not None:
+        if re.search("get_ipython.*pinfo", lines[i]) is not None:
             lines[i] = ''
 
         # Discard the lines that use the GUI


### PR DESCRIPTION
The function `get_emittance` raises an error when the array of particles is empty. This does not occur with `get_divergence` for instance, because of some specific safeguards in the function `wstd`. 

This pull request adds similar safeguards for the calculations of averages in the function `get_emittance`. 

Note: I named the new averaging function `w_ave` (instead of `wave` which might be confusing). For consistency, I also renamed `wstd` as `w_std`.