### PR TITLE
Adapt envelope calculation for 2D arrays

### DIFF
--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -430,17 +430,16 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
                                 coord=pol, theta=theta, m=m,
                                 slicing_dir=slicing_dir )
         info = field[1]
-        if index == 'center':
-            # Get central slice
+        if index == 'all':
+            # Filter the full 2D array
+            envelope = self._fft_filter(field[0], freq_filter)
+        elif index == 'center':
+            # Filter the central slice (1D array)
             field_slice = field[0][int( field[0].shape[0] / 2), :]
-            # Calculate inverse FFT of filtered FFT array
             envelope = self._fft_filter(field_slice, freq_filter)
-        elif index == 'all':
-            envelope = np.array([ self._fft_filter(field[0][i, :], freq_filter)
-                                  for i in range(field[0].shape[0]) ])
         else:
+            # Filter the requested slice (2D array)
             field_slice = field[0][index, :]
-            # Calculate inverse FFT of filtered FFT array
             envelope = self._fft_filter(field_slice, freq_filter)
 
         # Restrict the metainformation to 1d if needed
@@ -475,8 +474,10 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
 
         Parameters
         ----------
-        field : 1D array
+        field : 1D array or 2D array
             Array with input data in time/space domain
+            When a 2D array is provided, filtering is performed along
+            the last dimension.
 
         freq_filter : float
             Frequency range in percent around the dominant frequency which will
@@ -484,15 +485,22 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
 
         Returns
         -------
-        A 1D array with filtered input data in time/space domain
+        A 1D array or 2D array with filtered input data in time/space domain
         """
-        # Number of sample points
-        N = field.size
-        # Fourier transform of the field slice
-        fft_field_slice = np.fft.fft(field)
+        # Number of sample points along the filtered direction
+        N = field.shape[-1]
         fft_freqs = np.fft.fftfreq(N)
+        # Fourier transform of the field
+        fft_field = np.fft.fft(field, axis=-1)
         # Find central frequency
-        central_freq_i = np.argmax(np.abs(fft_field_slice[:int(N / 2)]))
+        # (the code below works for both 1D and 2D arrays, and finds
+        # the global maximum across all dimensions in the case of the 2D array)
+        central_freq_i = np.unravel_index( np.argmax( np.abs(fft_field) ),
+                dims=fft_field.shape )[-1]
+        if central_freq_i > int( N / 2 ):
+            # Wrap index around, if it turns out to be in the
+            # negative-frequency part of the fft range
+            central_freq_i = N - central_freq_i
         central_freq = fft_freqs[central_freq_i]
         # Filter frequencies higher than central_freq * freq_filter/100
         filter_bound = central_freq * freq_filter / 100.
@@ -501,12 +509,21 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         filter_freq_range_i = central_freq_i - filter_i
         # Write filtered FFT array
         filtered_fft = np.zeros_like( field, dtype=np.complex )
-        filtered_fft[int(N / 2) - filter_freq_range_i:
-                     int(N / 2) + filter_freq_range_i] \
-        = fft_field_slice[central_freq_i - filter_freq_range_i:
-                          central_freq_i + filter_freq_range_i]
-        # Calculate inverse FFT of filtered FFT array
-        envelope = np.abs(np.fft.ifft(np.fft.fftshift(2 * filtered_fft)))
+        # - Indices in the original fft array
+        i_fft_min = central_freq_i - filter_freq_range_i
+        i_fft_max = central_freq_i + filter_freq_range_i
+        # - Indices in the new filtered array
+        i_filter_min = int(N / 2) - filter_freq_range_i
+        i_filter_max = int(N / 2) + filter_freq_range_i
+        if field.ndim == 2:
+            filtered_fft[ :, i_filter_min:i_filter_max] = \
+                2 * fft_field[ :, i_fft_min:i_fft_max ]
+        elif field.ndim == 1:
+            filtered_fft[ i_filter_min:i_filter_max] = \
+                2 * fft_field[ i_fft_min:i_fft_max ]
+        # Calculate inverse FFT of filtered FFT array (along the last axis)
+        envelope = np.abs( np.fft.ifft(
+            np.fft.fftshift( filtered_fft, axes=-1 ), axis=-1 ) )
 
         # Return the result
         return( envelope )


### PR DESCRIPTION
@dpgrote recently pointed out to me that the result of `get_laser_envelope` sometimes looked weird in 2D, with sharp horizontal lines, as in the example below:
<img width="399" alt="cut" src="https://user-images.githubusercontent.com/6685781/31469661-67d3627e-ae97-11e7-8ec2-01c221ffab18.png">

Upon further investigation, he found that this is because the calculation of the central frequency (around which filtering is performed in order to get the envelope) is performed independently for each horizontal line. Thus, each horizontal line is potentially filtered differently.

This pull request solves this problem by calculating the central frequency only once, for the whole 2D array. This is done by generalizing the function `_fft_filter` so that it can accept both 1D arrays and 2D arrays as input (instead of only 1D arrays before).

Here is the same image with the code from this PR:
<img width="378" alt="uncut" src="https://user-images.githubusercontent.com/6685781/31469784-fc453a72-ae97-11e7-9034-5f28423459ee.png">
