### PR TITLE
Ipywidgets error

### DIFF
--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -8,14 +8,17 @@ Copyright 2015-2016, openPMD-viewer contributors
 Authors: Remi Lehe, Axel Huebl
 License: 3-Clause-BSD-LBNL
 """
-
-from ipywidgets import widgets, __version__
-from IPython.core.display import display, clear_output
 import math
-import matplotlib
-import matplotlib.pyplot as plt
 from functools import partial
-ipywidgets_version = int(__version__[0])
+try:
+    from ipywidgets import widgets, __version__
+    ipywidgets_version = int(__version__[0])
+    from IPython.core.display import display, clear_output
+    import matplotlib
+    import matplotlib.pyplot as plt
+    dependencies_installed = True
+except ImportError:
+    dependencies_installed = False
 
 
 class InteractiveViewer(object):
@@ -40,6 +43,11 @@ class InteractiveViewer(object):
         kw: dict
             Extra arguments to pass to matplotlib's imshow
         """
+        # Check that the dependencies have been installed
+        if not dependencies_installed:
+            raise RuntimeError("Failed to load the openPMD-viewer slider.\n"
+                "(Make sure that ipywidgets and matplotlib are installed.)")
+
         # -----------------------
         # Define useful functions
         # -----------------------

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -18,19 +18,7 @@ from .data_reader.params_reader import read_openPMD_params
 from .data_reader.particle_reader import read_species_data
 from .data_reader.field_reader import read_field_1d, read_field_2d, \
     read_field_circ, read_field_3d, get_grid_parameters
-
-
-# Check wether the interactive interface can be loaded
-try:
-    # If yes, use the InteractiveViewer as a parent class
-    from .interactive import InteractiveViewer
-    parent_class = InteractiveViewer
-except ImportError:
-    # Otherwise, use the default parent class
-    print('[opmd_viewer] Failed to import the interactive interface.\n'
-          '(Make sure that ipywidgets is installed.)\n'
-          'The opmd_viewer API is nonetheless working.')
-    parent_class = object
+from .interactive import InteractiveViewer
 
 
 # Define a custom Exception
@@ -39,9 +27,7 @@ class OpenPMDException(Exception):
     pass
 
 
-# Define the OpenPMDTimeSeries class and have it inherit
-# from the parent class defined above
-class OpenPMDTimeSeries(parent_class):
+class OpenPMDTimeSeries(InteractiveViewer):
     """
     Main class for the exploration of an openPMD timeseries
 


### PR DESCRIPTION
Currently openPMD-viewer prints an (ugly-looking) message whenever ipywidgets is not installed. This is a bit superfluous, since openPMD-viewer can be used for scripting or other non-jupyter uses, and since in this case, the error message is unneeded.

This pull request modifies the code so that an error message is printed only if the user attempts to call the `slider` method.