### PR TITLE
Close #177  `%matplotlib` on MacOS will not let the plots pop-up

### DIFF
--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -14,12 +14,12 @@ from opmd_viewer import OpenPMDTimeSeries, FieldMetaInformation
 import numpy as np
 import scipy.constants as const
 from scipy.optimize import curve_fit
-
+from opmd_viewer.openpmd_timeseries.plotter import check_matplotlib
 try:
     import matplotlib.pyplot as plt
-    matplotlib_installed = True
 except ImportError:
-    matplotlib_installed = False
+    # Any error will be caught later by `check_matplotlib`
+    pass
 
 
 class LpaDiagnostics( OpenPMDTimeSeries ):
@@ -158,8 +158,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             i += 1
         # Plot the result if needed
         if plot:
-            if not matplotlib_installed:
-                raise_matplotlib_error()
+            check_matplotlib()
             iteration = self.iterations[ self._current_i ]
             time_fs = 1.e15 * self.t[ self._current_i ]
             plt.plot(z_pos, spreads, **kw)
@@ -360,8 +359,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             global_offset=(np.min(z) + len_z / bins / 2,), position=(0,))
         # Plot the result if needed
         if plot:
-            if not matplotlib_installed:
-                raise_matplotlib_error()
+            check_matplotlib()
             iteration = self.iterations[ self._current_i ]
             time_fs = 1.e15 * self.t[ self._current_i ]
             plt.plot( info.z, current, **kw)
@@ -456,8 +454,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
 
         # Plot the result if needed
         if plot:
-            if not matplotlib_installed:
-                raise_matplotlib_error()
+            check_matplotlib()
             iteration = self.iterations[ self._current_i ]
             time_fs = 1.e15 * self.t[ self._current_i ]
             if index != 'all':
@@ -657,8 +654,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
 
         # Plot the field if required
         if plot:
-            if not matplotlib_installed:
-                raise_matplotlib_error()
+            check_matplotlib()
             iteration = self.iterations[ self._current_i ]
             time_fs = 1.e15 * self.t[ self._current_i ]
             plt.plot( spect_info.omega, spectrum, **kw )
@@ -922,8 +918,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
 
         # Plot the result if needed
         if plot:
-            if not matplotlib_installed:
-                raise_matplotlib_error()
+            check_matplotlib()
             iteration = self.iterations[ self._current_i ]
             time_fs = 1.e15 * self.t[ self._current_i ]
             plt.imshow( spectrogram, extent=info.imshow_extent, aspect='auto',
@@ -1015,9 +1010,3 @@ def gaussian_profile( x, x0, E0, w0 ):
     A 1darray of floats, of the same length as x
     """
     return( E0 * np.exp( -(x - x0) ** 2 / w0 ** 2 ) )
-
-
-def raise_matplotlib_error():
-    """Raise an error telling the user to install matplotlib."""
-    raise RuntimeError("Failed to plot result.\n"
-                       "(Make sure that matplotlib is installed.)")

--- a/opmd_viewer/notebook_starter/Template_notebook.ipynb
+++ b/opmd_viewer/notebook_starter/Template_notebook.ipynb
@@ -18,8 +18,8 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "from opmd_viewer import OpenPMDTimeSeries\n",
-    "%matplotlib\n",
-    "# or `%matplotlib notebook` for inline plots"
+    "%matplotlib notebook\n",
+    "# or `%matplotlib inline` for non-interactive plots"
    ]
   },
   {

--- a/opmd_viewer/openpmd_timeseries/plotter.py
+++ b/opmd_viewer/openpmd_timeseries/plotter.py
@@ -9,6 +9,8 @@ Author: Remi Lehe
 License: 3-Clause-BSD-LBNL
 """
 try:
+    import warnings
+    import matplotlib
     import matplotlib.pyplot as plt
     matplotlib_installed = True
 except ImportError:
@@ -77,8 +79,7 @@ class Plotter(object):
            Additional options to be passed to matplotlib's hist
         """
         # Check if matplotlib is available
-        if not matplotlib_installed:
-            raise_matplotlib_error()
+        check_matplotlib()
 
         # Find the iteration and time
         iteration = self.iterations[current_i]
@@ -126,8 +127,7 @@ class Plotter(object):
            Additional options to be passed to matplotlib's hist
         """
         # Check if matplotlib is available
-        if not matplotlib_installed:
-            raise_matplotlib_error()
+        check_matplotlib()
 
         # Find the iteration and time
         iteration = self.iterations[current_i]
@@ -166,8 +166,7 @@ class Plotter(object):
            along the 1st axis (first list) and 2nd axis (second list)
         """
         # Check if matplotlib is available
-        if not matplotlib_installed:
-            raise_matplotlib_error()
+        check_matplotlib()
 
         # Find the iteration and time
         iteration = self.iterations[current_i]
@@ -225,8 +224,7 @@ class Plotter(object):
            along the 1st axis (first list) and 2nd axis (second list)
         """
         # Check if matplotlib is available
-        if not matplotlib_installed:
-            raise_matplotlib_error()
+        check_matplotlib()
 
         # Find the iteration and time
         iteration = self.iterations[current_i]
@@ -269,7 +267,16 @@ class Plotter(object):
             plt.ylim( plot_range[1][0], plot_range[1][1] )
 
 
-def raise_matplotlib_error():
-    """Raise an error telling the user to install matplotlib."""
-    raise RuntimeError( "Failed to import the openPMD-viewer plotter.\n"
-        "(Make sure that matplotlib is installed.)")
+def check_matplotlib():
+    """Raise error messages or warnings when potential issues when
+    potenial issues with matplotlib are detected."""
+
+    if not matplotlib_installed:
+        raise RuntimeError( "Failed to import the openPMD-viewer plotter.\n"
+            "(Make sure that matplotlib is installed.)")
+
+    elif ('MacOSX' in matplotlib.get_backend()):
+        warnings.warn("\n\nIt seems that you are using the matplotlib MacOSX "
+        "backend. \n(This typically obtained when typing `%matplotlib`.)\n"
+        "With recent version of Jupyter, the plots might not appear.\nIn this "
+        "case, switch to `%matplotlib notebook` and restart the notebook.")


### PR DESCRIPTION
This pull request closes #177 by:
- Printing warnings when the MacOSX backend is used.
- Setting the default backend (in the quick-start notebook) to `matplotlib notebook`