### PR TITLE
Generalize the code to handle files containing different geometries

### DIFF
--- a/opmd_viewer/openpmd_timeseries/data_reader/field_reader.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/field_reader.py
@@ -329,9 +329,9 @@ def get_grid_parameters( dfile, avail_fields, metadata ):
     # (This function is for the purpose of histogramming the particles;
     # in this case, the highest dimensionality ensures that more particle
     # quantities can be properly histogrammed.)
-    geometry_ranking = {'1dcartesian':0, '2dcartesian':1,
-                        'thetaMode':2, '3dcartesian':3}
-    fields_ranking = [ geometry_ranking[ metadata[field]['geometry'] ] \
+    geometry_ranking = {'1dcartesian': 0, '2dcartesian': 1,
+                        'thetaMode': 2, '3dcartesian': 3}
+    fields_ranking = [ geometry_ranking[ metadata[field]['geometry'] ]
                         for field in avail_fields ]
     index_best_field = fields_ranking.index( max(fields_ranking) )
     field_name = avail_fields[ index_best_field ]

--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -188,9 +188,9 @@ class InteractiveViewer(object):
                 whenever a change of a widget happens
                 (see docstring of ipywidgets.Widget.observe)
             """
-            if self.avail_fields[change['new']] == 'scalar':
+            if self.fields_metadata[change['new']]['type'] == 'scalar':
                 coord_button.disabled = True
-            elif self.avail_fields[change['new']] == 'vector':
+            elif self.fields_metadata[change['new']]['type'] == 'vector':
                 coord_button.disabled = False
             refresh_field()
 
@@ -290,30 +290,34 @@ class InteractiveViewer(object):
             # Field button
             fieldtype_button = create_toggle_buttons(
                 description='Field:',
-                options=sorted(self.avail_fields.keys()))
+                options=sorted(self.avail_fields))
             fieldtype_button.observe( refresh_field_type, 'value', 'change' )
 
             # Coord button
-            if self.geometry == "thetaMode":
+            if "thetaMode" in self.avail_geom:
                 coord_button = create_toggle_buttons(
                     description='Coord:', options=['x', 'y', 'z', 'r', 't'])
-            elif self.geometry in \
-                    ["1dcartesian", "2dcartesian", "3dcartesian"]:
+            else:
                 coord_button = create_toggle_buttons(
                     description='Coord:', options=['x', 'y', 'z'])
             coord_button.observe( refresh_field, 'value', 'change')
             # Mode and theta button (for thetaMode)
+            # (First find all available cylindrical modes, across all fields)
+            avail_circ_modes = []
+            for field in self.avail_fields:
+                for m in self.fields_metadata[field]['avail_circ_modes']:
+                    if not m in avail_circ_modes:
+                        avail_circ_modes.append(m)
             mode_button = create_toggle_buttons(description='Mode:',
-                                                options=self.avail_circ_modes)
+                                                options=avail_circ_modes)
             mode_button.observe( refresh_field, 'value', 'change')
             theta_button = widgets.FloatSlider( value=0.,
                     min=-math.pi / 2, max=math.pi / 2)
             set_widget_dimensions( theta_button, width=190 )
             theta_button.observe( refresh_field, 'value', 'change')
             # Slicing buttons (for 3D)
-            slicing_dir_button = create_toggle_buttons(
-                value=self.axis_labels[0], options=self.axis_labels,
-                description='Slice normal:')
+            slicing_dir_button = create_toggle_buttons( value='y',
+                options=['x', 'y', 'z'], description='Slice normal:')
             slicing_dir_button.observe( refresh_field, 'value', 'change' )
             slicing_button = widgets.FloatSlider( min=-1., max=1., value=0.)
             set_widget_dimensions( slicing_button, width=180 )
@@ -344,31 +348,25 @@ class InteractiveViewer(object):
             # Containers
             # ----------
             # Field type container
-            if self.geometry == "thetaMode":
-                container_fields = widgets.VBox( children=[
-                    fieldtype_button, coord_button, mode_button,
-                    add_description('Theta:', theta_button) ])
-            elif self.geometry in ["1dcartesian", "2dcartesian"]:
-                container_fields = widgets.VBox(
-                    children=[fieldtype_button, coord_button])
-            elif self.geometry == "3dcartesian":
-                container_fields = widgets.VBox( children=[
-                    fieldtype_button, coord_button, slicing_dir_button,
-                    add_description("Slicing:", slicing_button) ])
+            field_widget_list = [fieldtype_button, coord_button]
+            if "thetaMode" in self.avail_geom:
+                # Add widgets specific to azimuthal modes
+                field_widget_list += [ mode_button,
+                                add_description('Theta:', theta_button)]
+            elif "3dcartesian" in self.avail_geom:
+                # Add widgets specific to cartesian 3d
+                field_widget_list += [ slicing_dir_button,
+                    add_description("Slicing:", slicing_button) ]
+            container_fields = widgets.VBox( children=field_widget_list )
             set_widget_dimensions( container_fields, width=330 )
             # Plotting options container
             container_fld_cbar = fld_color_button.to_container()
             container_fld_hrange = fld_hrange_button.to_container()
             container_fld_vrange = fld_vrange_button.to_container()
-            if self.geometry == "1dcartesian":
-                container_fld_plots = widgets.VBox( children=[
-                    add_description("<b>Figure:</b>", fld_figure_button),
-                    container_fld_vrange, container_fld_hrange ])
-            else:
-                container_fld_plots = widgets.VBox( children=[
-                    add_description("<b>Figure:</b>", fld_figure_button),
-                    container_fld_cbar, container_fld_vrange,
-                    container_fld_hrange ])
+            container_fld_plots = widgets.VBox( children=[
+                add_description("<b>Figure:</b>", fld_figure_button),
+                container_fld_cbar, container_fld_vrange,
+                container_fld_hrange ])
             set_widget_dimensions( container_fld_plots, width=330 )
             # Accordion for the field widgets
             accord1 = widgets.Accordion(

--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -323,7 +323,7 @@ class InteractiveViewer(object):
             avail_circ_modes = []
             for field in self.avail_fields:
                 for m in self.fields_metadata[field]['avail_circ_modes']:
-                    if not m in avail_circ_modes:
+                    if m not in avail_circ_modes:
                         avail_circ_modes.append(m)
             mode_button = create_toggle_buttons(description='Mode:',
                                                 options=avail_circ_modes)

--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -188,10 +188,27 @@ class InteractiveViewer(object):
                 whenever a change of a widget happens
                 (see docstring of ipywidgets.Widget.observe)
             """
-            if self.fields_metadata[change['new']]['type'] == 'scalar':
-                coord_button.disabled = True
-            elif self.fields_metadata[change['new']]['type'] == 'vector':
+            new_field = change['new']
+            # Activate/deactivate vector fields
+            if self.fields_metadata[new_field]['type'] == 'vector':
                 coord_button.disabled = False
+            else:
+                coord_button.disabled = True
+            # Activate/deactivate cylindrical-specific widgets
+            if self.fields_metadata[new_field]['geometry'] == 'thetaMode':
+                mode_button.disabled = False
+                theta_button.disabled = False
+            else:
+                mode_button.disabled = True
+                theta_button.disabled = True
+            # Activate/deactivate 3d-specific widgets
+            if self.fields_metadata[new_field]['geometry'] == '3dcartesian':
+                slicing_dir_button.disabled = False
+                slicing_button.disabled = False
+            else:
+                slicing_dir_button.disabled = True
+                slicing_button.disabled = True
+            # Show the fields
             refresh_field()
 
         def refresh_species(change=None):

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -75,10 +75,9 @@ class OpenPMDTimeSeries(InteractiveViewer):
         # - Extract parameters from the first file
         t, params0 = read_openPMD_params(self.h5_files[0])
         self.t[0] = t
-        self.avail_fields = params0['avail_fields']
         self.extensions = params0['extensions']
-        if self.avail_fields is not None:
-            self.fields_metadata = params0['fields_metadata']
+        self.avail_fields = params0['avail_fields']
+        self.fields_metadata = params0['fields_metadata']
         self.avail_species = params0['avail_species']
         self.avail_record_components = \
             params0['avail_record_components']
@@ -303,7 +302,7 @@ class OpenPMDTimeSeries(InteractiveViewer):
             if use_field_mesh and self.avail_fields is not None:
                 # Extract the grid resolution
                 grid_size_dict, grid_range_dict = get_grid_parameters(
-                    file_handle, self.avail_fields, self.geometry )
+                    file_handle, self.avail_fields, self.fields_metadata )
                 # For each direction, modify the number of bins, so that
                 # the resolution is a multiple of the grid resolution
                 for i_var in range(len(var_list)):
@@ -431,7 +430,7 @@ class OpenPMDTimeSeries(InteractiveViewer):
                     "argument accordingly." % (field, coord_list))
         # Check the mode (for thetaMode)
         if self.fields_metadata[field]['geometry'] == "thetaMode":
-            avail_circ_modes = self.fields_metadata['avail_circ_modes']
+            avail_circ_modes = self.fields_metadata[field]['avail_circ_modes']
             if str(m) not in avail_circ_modes:
                 mode_list = '\n - '.join(avail_circ_modes)
                 raise OpenPMDException(

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -78,7 +78,7 @@ class OpenPMDTimeSeries(InteractiveViewer):
         self.extensions = params0['extensions']
         self.avail_fields = params0['avail_fields']
         self.fields_metadata = params0['fields_metadata']
-        self.avail_geom = set( self.fields_metadata[field]['geometry'] \
+        self.avail_geom = set( self.fields_metadata[field]['geometry']
                                 for field in self.avail_fields )
         # Extract information of the particles
         self.avail_species = params0['avail_species']

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -78,6 +78,9 @@ class OpenPMDTimeSeries(InteractiveViewer):
         self.extensions = params0['extensions']
         self.avail_fields = params0['avail_fields']
         self.fields_metadata = params0['fields_metadata']
+        self.avail_geom = set( self.fields_metadata[field]['geometry'] \
+                                for field in self.avail_fields )
+        # Extract information of the particles
         self.avail_species = params0['avail_species']
         self.avail_record_components = \
             params0['avail_record_components']


### PR DESCRIPTION
@caozigao recently pointed out that the `openPMD-viewer` does not work properly when a file contains different geometries (e.g. 2d fields and 3d fields). (Btw, thanks for reporting the issue!)

This pull request generalizes the code so as to fix this issue. I tested the code with the example created by [this script](https://github.com/openPMD/openPMD-validator/blob/fix_example/createExamples_h5.py), which contains both cylindrical and 2d fields.

Here is a summary of the changes in this PR:
- The attributes `self.geometry` and `self.available_circ_modes`, etc. have been replaced by `self.fields_metadata` which contains this information **for each field**. This is then used in `get_field`, retrieving the relevant metadata **for the field that the user requests**.
- The attribute `self.avail_fields` used to be a dictionary, showing whether a given field is a vector or a scalar. This information is now moved to `self.fields_metadata`, and instead `self.avail_fields` is simply a list of the available fields.
- I also added an attribute `self.avail_geom` which lists all geometries in the present file. This convenient when creating the slider.
- One difficulty was the anti-aliasing code (see PR #132). There, to avoid aliasing when doing particle histograms, we were using information of the grid to choose the histogram bin size. However, when different geometries are used in the same file, it is unclear which grid information to use. To keep the code simple, I made the choice of picking the grid with the highest dimension (e.g. 3d rather than 2d, when available).
- I also updated the slider, so that the relevant buttons appear for files that contain different geometries. Some of the buttons even activate/deactivate depending on the geometry of the requested field (but not all, though: for instance the radial field component `r` is still available for cartesian fields, if the file also contains radial fields... This could be fixed in a future PR.)