### PR TITLE
Tutorials: Binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status master](https://img.shields.io/travis/openPMD/openPMD-viewer/master.svg?label=master)](https://travis-ci.org/openPMD/openPMD-viewer/branches)
 [![Build Status dev](https://img.shields.io/travis/openPMD/openPMD-viewer/dev.svg?label=dev)](https://travis-ci.org/openPMD/openPMD-viewer/branches)
 [![pypi version](https://img.shields.io/pypi/v/openPMD-viewer.svg)](https://pypi.python.org/pypi/openPMD-viewer)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/openPMD/openPMD-viewer/master?filepath=tutorials%2F)
 [![License](https://img.shields.io/pypi/l/openPMD-viewer.svg)](LICENSE.txt)
 
 ## Overview
@@ -26,6 +27,9 @@ visualize the data.
 The notebooks in the folder `tutorials/` demonstrate how to use both
 the API and the interactive GUI. You can view these notebooks online
 [here](https://github.com/openPMD/openPMD-viewer/tree/master/tutorials).
+
+Alternatively, you can even
+[*run* our tutorials online](https://mybinder.org/v2/gh/openPMD/openPMD-viewer/master?filepath=tutorials%2F)!
 
 You can also download and run these notebooks on your local computer
 (when viewing the notebooks with the above link, click on `Raw` to be able to

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,4 @@
+# full dependencies for the tutorials, e.g. when run on binder
+openPMD-viewer
+matplotlib
+wget

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(name='openPMD-viewer',
       extras_require = {
         'GUI':  ["ipywidgets", "matplotlib"],
         'plot': ["matplotlib"],
+        'tutorials': ["ipywidgets", "matplotlib", "wget"]
         },
       cmdclass={'test': PyTest},
       platforms='any',


### PR DESCRIPTION
Enables [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/ax3l/openPMD-viewer/topic-binder?filepath=tutorials%2F) support for our tutorials.

With binder, our users can quickly expore the features of openPMD-viewer online - without the need to install anything. It's just amazing.