### PR TITLE
Slider figure

### DIFF
--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -26,7 +26,7 @@ class InteractiveViewer(object):
     def __init__(self):
         pass
 
-    def slider(self, figsize=(6, 5),
+    def slider(self, figsize=(6, 5), fields_figure=0, particles_figure=1,
                exclude_particle_records=['charge', 'mass'], **kw):
         """
         Navigate the simulation using a slider
@@ -35,6 +35,11 @@ class InteractiveViewer(object):
         -----------
         figsize: tuple
             Size of the figures
+
+        fields_figure, particle_figure: ints
+            The number of the matplotlib figure on which the fields
+            and the particles will be plotted respectively.
+            (This is similar to calling `plt.figure(fields_figure)`)
 
         exclude_particle_records: list of strings
             List of particle quantities that should not be displayed
@@ -343,7 +348,7 @@ class InteractiveViewer(object):
             # Plotting options
             # ----------------
             # Figure number
-            fld_figure_button = widgets.IntText( value=0 )
+            fld_figure_button = widgets.IntText( value=fields_figure )
             set_widget_dimensions( fld_figure_button, width=50 )
             # Colormap button
             fld_color_button = ColorBarSelector( refresh_field,
@@ -427,7 +432,7 @@ class InteractiveViewer(object):
             # Plotting options
             # ----------------
             # Figure number
-            ptcl_figure_button = widgets.IntText( value=1 )
+            ptcl_figure_button = widgets.IntText( value=particles_figure )
             set_widget_dimensions( ptcl_figure_button, width=50 )
             # Number of bins
             ptcl_bins_button = widgets.IntText( value=100 )

--- a/tutorials/3_Introduction-to-the-GUI.ipynb
+++ b/tutorials/3_Introduction-to-the-GUI.ipynb
@@ -19,10 +19,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os, sys, tarfile, wget\n",
@@ -51,13 +49,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline"
+    "%matplotlib notebook"
    ]
   },
   {
@@ -72,10 +68,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "from opmd_viewer import OpenPMDTimeSeries"
@@ -90,10 +84,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "ts_2d = OpenPMDTimeSeries('./example-2d/hdf5/')"
@@ -108,10 +100,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "ts_2d.slider()"
@@ -148,14 +138,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "ts_3d = OpenPMDTimeSeries('./example-3d/hdf5/')\n",
-    "ts_3d.slider()"
+    "ts_3d.slider( fields_figure=2, particles_figure=3 )"
    ]
   },
   {
@@ -175,14 +163,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "ts_circ = OpenPMDTimeSeries('./example-thetaMode/hdf5/')\n",
-    "ts_circ.slider()"
+    "ts_circ.slider( fields_figure=4 )"
    ]
   },
   {
@@ -197,23 +183,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
When using `%matplotlib figure`, it is often needed to explicitly pass the figure number through the slider (otherwise the figure that gets updated is often at a completely different position in the notebook). 

However, when recreating/updating a slider, rerunning the cell that created it resets the figure number. This pull request allows the user to pass the figure number directly in the `slider` call instead (see the tutorial example).

I also updated the tutorial, so that `%matplotlib notebook` is used. This is because `%matplotlib inline` does not work well with the latest version of `ipywidgets` (see https://github.com/openPMD/openPMD-viewer/pull/176)
