### PR TITLE
Implement Cloud-In-Cell deposition (i.e. linear weights) for histogramming

### DIFF
--- a/opmd_viewer/openpmd_timeseries/cython_function.pyx
+++ b/opmd_viewer/openpmd_timeseries/cython_function.pyx
@@ -1,7 +1,11 @@
 import numpy as np
 cimport numpy as np
 from cpython cimport bool
+cimport cython
+from libc.math cimport floor
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def extract_indices_cython(
     np.ndarray[np.int64_t, ndim=1] original_indices,
     np.ndarray[np.int64_t, ndim=1] selected_indices,
@@ -40,3 +44,37 @@ def extract_indices_cython(
                 i_fill += 1
 
     return( i_fill )
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def histogram_cic_1d(
+    np.ndarray[np.float64_t, ndim=1] q1,
+    np.ndarray[np.float64_t, ndim=1] w,
+    int nbins, double bins_start, double bins_end ):
+    """
+    # TODO
+    """
+    # Define various scalars
+    cdef double bin_spacing = (bins_end-bins_start)/nbins
+    cdef double inv_spacing = 1./bin_spacing
+    cdef int n_ptcl = len(q1)
+    cdef int i_low_bin
+    cdef double q1_cell
+    cdef double S_low
+
+    # Allocate array for histogrammed data
+    hist_data = np.zeros( nbins, dtype=np.float64 )
+
+    # Go through particle array and bin the data
+    for i in xrange(n_ptcl):
+        # Calculate the index of lower bin to which this particle contributes
+        q1_cell = (q1[i] - bins_start) * inv_spacing
+        i_low_bin = <int> floor( q1_cell )
+        # Calculate corresponding CIC shape and deposit the weight
+        S_low = 1. - (q1_cell - i_low_bin)
+        if (i_low_bin >= 0) and (i_low_bin < nbins):
+            hist_data[ i_low_bin ] += w[i] * S_low
+        if (i_low_bin + 1 >= 0) and (i_low_bin + 1 < nbins):
+            hist_data[ i_low_bin + 1 ] += w[i] * (1. - S_low)
+
+    return( hist_data )

--- a/opmd_viewer/openpmd_timeseries/cython_function.pyx
+++ b/opmd_viewer/openpmd_timeseries/cython_function.pyx
@@ -94,9 +94,9 @@ def histogram_cic_2d(
     """
     # Define various scalars
     cdef double bin_spacing_1 = (bins_end_1-bins_start_1)/nbins
-    cdef double bin_spacing_2 = (bins_end_1-bins_start_2)/nbins
     cdef double inv_spacing_1 = 1./bin_spacing_1
-    cdef double inv_spacing_1 = 1./bin_spacing_2
+    cdef double bin_spacing_2 = (bins_end_1-bins_start_2)/nbins
+    cdef double inv_spacing_2 = 1./bin_spacing_2
     cdef int n_ptcl = len(w)
     cdef int i1_low_bin, i2_low_bin
     cdef double q1_cell, q2_cell
@@ -107,11 +107,13 @@ def histogram_cic_2d(
 
     # Go through particle array and bin the data
     for i in xrange(n_ptcl):
+
         # Calculate the index of lower bin to which this particle contributes
         q1_cell = (q1[i] - bins_start_1) * inv_spacing_1
         q2_cell = (q2[i] - bins_start_2) * inv_spacing_2
         i1_low_bin = <int> floor( q1_cell )
-        i2_low_bin = <int> floor( q1_cell )
+        i2_low_bin = <int> floor( q2_cell )
+
         # Calculate corresponding CIC shape and deposit the weight
         S1_low = 1. - (q1_cell - i1_low_bin)
         S2_low = 1. - (q2_cell - i2_low_bin)
@@ -120,7 +122,7 @@ def histogram_cic_2d(
                 hist_data[ i1_low_bin, i2_low_bin ] += w[i]*S1_low*S2_low
             if (i2_low_bin+1 >= 0) and (i2_low_bin+1 < nbins):
                 hist_data[ i1_low_bin, i2_low_bin+1 ] += w[i]*S1_low*(1.-S2_low)
-        if (i_low_bin+1 >= 0) and (i_low_bin+1 < nbins):
+        if (i1_low_bin+1 >= 0) and (i1_low_bin+1 < nbins):
             if (i2_low_bin >= 0) and (i2_low_bin < nbins):
                 hist_data[ i1_low_bin+1, i2_low_bin ] += w[i]*(1.-S1_low)*S2_low
             if (i2_low_bin+1 >= 0) and (i2_low_bin+1 < nbins):

--- a/opmd_viewer/openpmd_timeseries/cython_function.pyx
+++ b/opmd_viewer/openpmd_timeseries/cython_function.pyx
@@ -87,15 +87,15 @@ def histogram_cic_2d(
     np.ndarray[np.float64_t, ndim=1] q1,
     np.ndarray[np.float64_t, ndim=1] q2,
     np.ndarray[np.float64_t, ndim=1] w,
-    int nbins, double bins_start_1, double bins_end_1,
-    double bins_start_2, double bins_end_2 ):
+    int nbins_1, double bins_start_1, double bins_end_1,
+    int nbins_2, double bins_start_2, double bins_end_2 ):
     """
     # TODO
     """
     # Define various scalars
-    cdef double bin_spacing_1 = (bins_end_1-bins_start_1)/nbins
+    cdef double bin_spacing_1 = (bins_end_1-bins_start_1)/nbins_1
     cdef double inv_spacing_1 = 1./bin_spacing_1
-    cdef double bin_spacing_2 = (bins_end_1-bins_start_2)/nbins
+    cdef double bin_spacing_2 = (bins_end_2-bins_start_2)/nbins_2
     cdef double inv_spacing_2 = 1./bin_spacing_2
     cdef int n_ptcl = len(w)
     cdef int i1_low_bin, i2_low_bin
@@ -103,7 +103,7 @@ def histogram_cic_2d(
     cdef double S1_low, S2_low
 
     # Allocate array for histogrammed data
-    hist_data = np.zeros( (nbins, nbins), dtype=np.float64 )
+    hist_data = np.zeros( (nbins_1, nbins_2), dtype=np.float64 )
 
     # Go through particle array and bin the data
     for i in xrange(n_ptcl):
@@ -117,15 +117,15 @@ def histogram_cic_2d(
         # Calculate corresponding CIC shape and deposit the weight
         S1_low = 1. - (q1_cell - i1_low_bin)
         S2_low = 1. - (q2_cell - i2_low_bin)
-        if (i1_low_bin >= 0) and (i1_low_bin < nbins):
-            if (i2_low_bin >= 0) and (i2_low_bin < nbins):
+        if (i1_low_bin >= 0) and (i1_low_bin < nbins_1):
+            if (i2_low_bin >= 0) and (i2_low_bin < nbins_2):
                 hist_data[ i1_low_bin, i2_low_bin ] += w[i]*S1_low*S2_low
-            if (i2_low_bin+1 >= 0) and (i2_low_bin+1 < nbins):
+            if (i2_low_bin+1 >= 0) and (i2_low_bin+1 < nbins_2):
                 hist_data[ i1_low_bin, i2_low_bin+1 ] += w[i]*S1_low*(1.-S2_low)
-        if (i1_low_bin+1 >= 0) and (i1_low_bin+1 < nbins):
-            if (i2_low_bin >= 0) and (i2_low_bin < nbins):
+        if (i1_low_bin+1 >= 0) and (i1_low_bin+1 < nbins_1):
+            if (i2_low_bin >= 0) and (i2_low_bin < nbins_2):
                 hist_data[ i1_low_bin+1, i2_low_bin ] += w[i]*(1.-S1_low)*S2_low
-            if (i2_low_bin+1 >= 0) and (i2_low_bin+1 < nbins):
+            if (i2_low_bin+1 >= 0) and (i2_low_bin+1 < nbins_2):
                 hist_data[ i1_low_bin+1, i2_low_bin+1 ] += w[i]*(1.-S1_low)*(1.-S2_low)
 
     return( hist_data )

--- a/opmd_viewer/openpmd_timeseries/cython_function.pyx
+++ b/opmd_viewer/openpmd_timeseries/cython_function.pyx
@@ -44,37 +44,3 @@ def extract_indices_cython(
                 i_fill += 1
 
     return( i_fill )
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-def histogram_cic_1d(
-    np.ndarray[np.float64_t, ndim=1] q1,
-    np.ndarray[np.float64_t, ndim=1] w,
-    int nbins, double bins_start, double bins_end ):
-    """
-    # TODO
-    """
-    # Define various scalars
-    cdef double bin_spacing = (bins_end-bins_start)/nbins
-    cdef double inv_spacing = 1./bin_spacing
-    cdef int n_ptcl = len(q1)
-    cdef int i_low_bin
-    cdef double q1_cell
-    cdef double S_low
-
-    # Allocate array for histogrammed data
-    hist_data = np.zeros( nbins, dtype=np.float64 )
-
-    # Go through particle array and bin the data
-    for i in xrange(n_ptcl):
-        # Calculate the index of lower bin to which this particle contributes
-        q1_cell = (q1[i] - bins_start) * inv_spacing
-        i_low_bin = <int> floor( q1_cell )
-        # Calculate corresponding CIC shape and deposit the weight
-        S_low = 1. - (q1_cell - i_low_bin)
-        if (i_low_bin >= 0) and (i_low_bin < nbins):
-            hist_data[ i_low_bin ] += w[i] * S_low
-        if (i_low_bin + 1 >= 0) and (i_low_bin + 1 < nbins):
-            hist_data[ i_low_bin + 1 ] += w[i] * (1. - S_low)
-
-    return( hist_data )

--- a/opmd_viewer/openpmd_timeseries/cython_function.pyx
+++ b/opmd_viewer/openpmd_timeseries/cython_function.pyx
@@ -15,7 +15,7 @@ def extract_indices_cython(
     """
     Go through the sorted arrays `pid` and `selected_pid`, and record
     the indices (of the array `pid`) where they match, by storing them
-place)
+    in the array `selected_indices` (this array is thus modified in-place)
 
     Return the number of elements that were filled in `selected_indices`
     """
@@ -53,7 +53,10 @@ def histogram_cic_1d(
     np.ndarray[np.float64_t, ndim=1] w,
     int nbins, double bins_start, double bins_end ):
     """
-    # TODO
+    Return an 1D histogram of the values in `q1` weighted by `w`,
+    consisting of `nbins` evenly-spaced bins between `bins_start`
+    and `bins_end`. Contribution to each bins is determined by the
+    CIC weighting scheme (i.e. linear weights).
     """
     # Define various scalars
     cdef double bin_spacing = (bins_end-bins_start)/nbins
@@ -90,7 +93,11 @@ def histogram_cic_2d(
     int nbins_1, double bins_start_1, double bins_end_1,
     int nbins_2, double bins_start_2, double bins_end_2 ):
     """
-    # TODO
+    Return an 2D histogram of the values in `q1` and `q2` weighted by `w`,
+    consisting of `nbins_1` bins in the first dimension and `nbins_2` bins
+    in the second dimension.
+    Contribution to each bins is determined by the
+    CIC weighting scheme (i.e. linear weights).
     """
     # Define various scalars
     cdef double bin_spacing_1 = (bins_end_1-bins_start_1)/nbins_1

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -113,7 +113,7 @@ class OpenPMDTimeSeries(InteractiveViewer):
     def get_particle(self, var_list=None, species=None, t=None, iteration=None,
             select=None, output=True, plot=False, nbins=150,
             plot_range=[[None, None], [None, None]],
-            use_field_mesh=True, **kw):
+            use_field_mesh=True, histogram_deposition='cic', **kw):
         """
         Extract a list of particle variables
         from an HDF5 file in the openPMD format.
@@ -186,6 +186,8 @@ class OpenPMDTimeSeries(InteractiveViewer):
              the spacing of the histogram is an integer multiple of the grid
              spacing. This avoids artifacts in the plot, whenever particles
              are regularly spaced in each cell of the spatial mesh.
+
+            # TODO: histogram deposition
 
         **kw : dict, otional
            Additional options to be passed to matplotlib's
@@ -324,13 +326,15 @@ class OpenPMDTimeSeries(InteractiveViewer):
             if len(data_list) == 1:
                 # Do the plotting
                 self.plotter.hist1d(data_list[0], w, var_list[0], species,
-                        self._current_i, hist_bins[0], hist_range[0], **kw)
+                        self._current_i, hist_bins[0], hist_range[0],
+                        deposition=histogram_deposition, **kw)
             # - In the case of two quantities
             elif len(data_list) == 2:
                 # Do the plotting
                 self.plotter.hist2d(data_list[0], data_list[1], w,
                     var_list[0], var_list[1], species,
-                    self._current_i, hist_bins, hist_range, **kw)
+                    self._current_i, hist_bins, hist_range,
+                    deposition=histogram_deposition, **kw)
         # Close the file
         file_handle.close()
 

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -187,7 +187,11 @@ class OpenPMDTimeSeries(InteractiveViewer):
              spacing. This avoids artifacts in the plot, whenever particles
              are regularly spaced in each cell of the spatial mesh.
 
-            # TODO: histogram deposition
+        histogram_deposition : string
+            Either `ngp` (Nearest Grid Point) or `cic` (Cloud-In-Cell)
+            When plotting the particle histogram, this determines how
+            particles affects neighboring bins.
+            `cic` (which is the default) leads to smoother results than `ngp`.
 
         **kw : dict, otional
            Additional options to be passed to matplotlib's

--- a/opmd_viewer/openpmd_timeseries/plotter.py
+++ b/opmd_viewer/openpmd_timeseries/plotter.py
@@ -8,6 +8,7 @@ Copyright 2015-2016, openPMD-viewer contributors
 Author: Remi Lehe
 License: 3-Clause-BSD-LBNL
 """
+import numpy as np
 try:
     import warnings
     import matplotlib
@@ -76,7 +77,7 @@ class Plotter(object):
            Extent of the histogram
 
         **kw : dict, otional
-           Additional options to be passed to matplotlib's hist
+           Additional options to be passed to matplotlib's bar function
         """
         # Check if matplotlib is available
         check_matplotlib()
@@ -86,8 +87,10 @@ class Plotter(object):
         time_fs = 1.e15 * self.t[current_i]
 
         # Do the plot
-        plt.hist(q1, bins=nbins, range=hist_range, weights=w, **kw)
-        plt.xlim(hist_range)
+        binned_data, bin_edges = np.histogram(q1, nbins, hist_range, weights=w)
+        bin_coords = 0.5 * ( bin_edges[1:] + bin_edges[:-1] )
+        plt.bar( bin_coords, binned_data, **kw )
+        plt.xlim( hist_range )
         plt.xlabel(quantity1, fontsize=self.fontsize)
         plt.title("%s:   t =  %.0f fs    (iteration %d)"
                   % (species, time_fs, iteration), fontsize=self.fontsize)
@@ -124,7 +127,7 @@ class Plotter(object):
            Extent of the histogram along each direction
 
         **kw : dict, otional
-           Additional options to be passed to matplotlib's hist
+           Additional options to be passed to matplotlib's imshow function
         """
         # Check if matplotlib is available
         check_matplotlib()
@@ -134,8 +137,11 @@ class Plotter(object):
         time_fs = 1.e15 * self.t[current_i]
 
         # Do the plot
-        plt.hist2d(q1, q2, bins=nbins, cmap=cmap, range=hist_range,
-                   vmin=vmin, vmax=vmax, weights=w, **kw)
+        binned_data, _, _ = np.histogram2d(
+            q1, q2, nbins, hist_range, weights=w)
+        plt.imshow( binned_data.T, extent=hist_range[0] + hist_range[1],
+             origin='lower', interpolation='nearest', aspect='auto',
+             cmap=cmap, vmin=vmin, vmax=vmax, **kw )
         plt.colorbar()
         plt.xlabel(quantity1, fontsize=self.fontsize)
         plt.ylabel(quantity2, fontsize=self.fontsize)

--- a/opmd_viewer/openpmd_timeseries/plotter.py
+++ b/opmd_viewer/openpmd_timeseries/plotter.py
@@ -181,8 +181,9 @@ class Plotter(object):
             binned_data, _, _ = np.histogram2d(
                 q1, q2, nbins, hist_range, weights=w)
         elif deposition == 'cic':
-            binned_data = histogram_cic_2d( q1, q2, w, nbins, hist_range[0][0],
-                hist_range[0][1], hist_range[1][0], hist_range[1][1] )
+            binned_data = histogram_cic_2d( q1, q2, w,
+                nbins[0], hist_range[0][0], hist_range[0][1],
+                nbins[1], hist_range[1][0], hist_range[1][1] )
         else:
             raise ValueError('Unknown deposition method: %s' % deposition)
 

--- a/opmd_viewer/openpmd_timeseries/plotter.py
+++ b/opmd_viewer/openpmd_timeseries/plotter.py
@@ -82,7 +82,10 @@ class Plotter(object):
            Extent of the histogram
 
         deposition : string
-            # TODO
+            Either `ngp` (Nearest Grid Point) or `cic` (Cloud-In-Cell)
+            When plotting the particle histogram, this determines how
+            particles affects neighboring bins.
+            `cic` (which is the default) leads to smoother results than `ngp`.
 
         **kw : dict, otional
            Additional options to be passed to matplotlib's bar function
@@ -98,16 +101,16 @@ class Plotter(object):
         if deposition == 'cic' and not cython_function_available:
             print_cic_unavailable()
             deposition = 'ngp'
-            # TODO: only call cic for float data
 
         # Bin the particle data
+        q1 = q1.astype( np.float64 )
         if deposition == 'ngp':
             binned_data, _ = np.histogram(q1, nbins, hist_range, weights=w)
         elif deposition == 'cic':
             binned_data = histogram_cic_1d(
                 q1, w, nbins, hist_range[0], hist_range[1])
         else:
-            raise ValueError('Unknown deposition method: %s' %deposition)
+            raise ValueError('Unknown deposition method: %s' % deposition)
 
         # Do the plot
         bin_size = (hist_range[1] - hist_range[0]) / nbins

--- a/setup.py
+++ b/setup.py
@@ -56,9 +56,9 @@ setup(name='openPMD-viewer',
       include_dirs=include_dirs,
       install_requires=install_requires,
       extras_require = {
-        'GUI':  ["ipywidgets", "matplotlib"],
-        'plot': ["matplotlib"],
-        'tutorials': ["ipywidgets", "matplotlib", "wget"]
+        'GUI':  ["ipywidgets", "matplotlib", "cython"],
+        'plot': ["matplotlib", "cython"],
+        'tutorials': ["ipywidgets", "matplotlib", "wget", "cython"]
         },
       cmdclass={'test': PyTest},
       platforms='any',


### PR DESCRIPTION
In `openPMD-viewer`, the particles are plotted through histograms. However, when particles are evenly-spaced, the histograms can have aliasing effects if the bin size is not a multiple of the spacing between particles. Currently, `openPMD-viewer` avoids this effect by choosing a bin size which is a multiple of the grid spacing. (see [PR #132](https://github.com/openPMD/openPMD-viewer/pull/132))

However, the information about grid spacing is not always available (e.g. if the fields data is not written in the openPMD file). In addition, the spacing between particles does not always align with the grid. 

For these reasons, this PR implements Cloud-In-Cell histogramming (as opposed to Nearest-Grid-Point histogramming), since this strongly reduces the aliasing effect, even when the grid spacing is not "matched" to the particle spacing. 

In practice, this PR adds the option `histogram_deposition` for the `get_particle` method. If `histogram_deposition` is set to `ngp`, then the code uses `numpy`'s `histogram` function (which is equivalent to the current `dev` branch). If `histogram_deposition` is set to `cic` (which is now the default), the code uses a custom-written cython function. I had to use a cython function because `numpy` does not have an available method for CIC deposition.

Here are is the comparison of 1D NGP and CIC histogramming for evenly-spaced particles (the position of the particles is represented by red dots.)
![histogram_1d](https://user-images.githubusercontent.com/6685781/34573732-f98fd3f8-f129-11e7-9ea7-ae987ec16e6c.png)

Here is a 2D comparison
![histogram_2d](https://user-images.githubusercontent.com/6685781/34574233-a459dcba-f12b-11e7-8d67-bb896957623d.png)

Many thanks to @jlvay for suggesting to implement this feature!
  