### PR TITLE
Avoid warning message about matplotlib inline

### DIFF
--- a/opmd_viewer/notebook_starter/Template_notebook.ipynb
+++ b/opmd_viewer/notebook_starter/Template_notebook.ipynb
@@ -16,10 +16,10 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "from opmd_viewer import OpenPMDTimeSeries\n",
     "%matplotlib notebook\n",
-    "# or `%matplotlib inline` for non-interactive plots"
+    "# or `%matplotlib inline` for non-interactive plots\n",
+    "import matplotlib.pyplot as plt\n",
+    "from opmd_viewer import OpenPMDTimeSeries"
    ]
   },
   {


### PR DESCRIPTION
When using the template notebook (through `openPMD_notebook`), the slider typically prints the message:
```
It seems that you are using ipywidgets 7 and `%matplotlib inline`.
This can cause issues when using `slider`.
In order to avoid this, you can either:
- use `%matplotlib notebook`
- or downgrade to ipywidgets 6 (with `pip` or `conda`).
```
even though `%matplotlib notebook` is used in the notebook!

@hightower8083 recently pointed out to me that this is because the line `%matplotlib notebook` appears *after* the `matplotlib` import. (Thanks!) Moving this line before the `matplotlib` import fixes this problem, which is what this PR does.