### PR TITLE
Close #196 Vertical axis does not work for for 1D histogram

### DIFF
--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -330,7 +330,7 @@ class OpenPMDTimeSeries(InteractiveViewer):
             if len(data_list) == 1:
                 # Do the plotting
                 self.plotter.hist1d(data_list[0], w, var_list[0], species,
-                        self._current_i, hist_bins[0], hist_range[0],
+                        self._current_i, hist_bins[0], hist_range,
                         deposition=histogram_deposition, **kw)
             # - In the case of two quantities
             elif len(data_list) == 2:

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -294,18 +294,18 @@ class OpenPMDTimeSeries(InteractiveViewer):
 
             # Determine the size of the histogram bins
             # - First pick default values
-            hist_range = []
+            hist_range = [[None, None], [None, None]]
             for i_data in range(len(data_list)):
                 data = data_list[i_data]
                 # Check if the user specified a value
                 if (plot_range[i_data][0] is not None) and \
                         (plot_range[i_data][1] is not None):
-                    hist_range.append( plot_range[i_data] )
+                    hist_range[i_data] =  plot_range[i_data]
                 # Else use min and max of data
                 elif len(data) != 0:
-                    hist_range.append( [ data.min(), data.max() ] )
+                    hist_range[i_data] = [ data.min(), data.max() ]
                 else:
-                    hist_range.append( [ -1., 1. ] )
+                    hist_range[i_data] = [ -1., 1. ]
             hist_bins = [ nbins for i_data in range(len(data_list)) ]
             # - Then, if required by the user, modify this values by
             #   fitting them to the spatial grid

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -300,7 +300,7 @@ class OpenPMDTimeSeries(InteractiveViewer):
                 # Check if the user specified a value
                 if (plot_range[i_data][0] is not None) and \
                         (plot_range[i_data][1] is not None):
-                    hist_range[i_data] =  plot_range[i_data]
+                    hist_range[i_data] = plot_range[i_data]
                 # Else use min and max of data
                 elif len(data) != 0:
                     hist_range[i_data] = [ data.min(), data.max() ]

--- a/opmd_viewer/openpmd_timeseries/plotter.py
+++ b/opmd_viewer/openpmd_timeseries/plotter.py
@@ -78,8 +78,8 @@ class Plotter(object):
         nbins : int
            Number of bins for the histograms
 
-        hist_range : list of 2 floats
-           Extent of the histogram
+        hist_range : list contains 2 lists of 2 floats
+           Extent of the histogram along each direction
 
         deposition : string
             Either `ngp` (Nearest Grid Point) or `cic` (Cloud-In-Cell)
@@ -105,18 +105,19 @@ class Plotter(object):
         # Bin the particle data
         q1 = q1.astype( np.float64 )
         if deposition == 'ngp':
-            binned_data, _ = np.histogram(q1, nbins, hist_range, weights=w)
+            binned_data, _ = np.histogram(q1, nbins, hist_range[0], weights=w)
         elif deposition == 'cic':
             binned_data = histogram_cic_1d(
-                q1, w, nbins, hist_range[0], hist_range[1])
+                q1, w, nbins, hist_range[0][0], hist_range[0][1])
         else:
             raise ValueError('Unknown deposition method: %s' % deposition)
 
         # Do the plot
-        bin_size = (hist_range[1] - hist_range[0]) / nbins
-        bin_coords = hist_range[0] + bin_size * ( 0.5 + np.arange(nbins) )
+        bin_size = (hist_range[0][1] - hist_range[0][0]) / nbins
+        bin_coords = hist_range[0][0] + bin_size * ( 0.5 + np.arange(nbins) )
         plt.bar( bin_coords, binned_data, width=bin_size, **kw )
-        plt.xlim( hist_range )
+        plt.xlim( hist_range[0] )
+        plt.ylim( hist_range[1] )
         plt.xlabel(quantity1, fontsize=self.fontsize)
         plt.title("%s:   t =  %.0f fs    (iteration %d)"
                   % (species, time_fs, iteration), fontsize=self.fontsize)


### PR DESCRIPTION
Close #196

For the 1D particle histogram, there is currently no way to scale the vertical axis:
- When using `ts.get_particle` and setting the `plot_range` option, the second list of `plot_range` (which corresponds to the vertical axis) is ignored.
- When using the slider, the widget for vertical axis is ignored (this is related to the above issue since the slider uses `ts.get_particle` under the hood.)

This PR fixes the above issue, by having `ts.get_particle` use the full `plot_range`.