### PR TITLE
Remove microns and femtoseconds

### DIFF
--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -69,8 +69,8 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         select : dict, optional
             Either None or a dictionary of rules
             to select the particles, of the form
-            'x' : [-4., 10.]   (Particles having x between -4 and 10 microns)
-            'z' : [0, 100] (Particles having x between 0 and 100 microns)
+            'x' : [-4., 10.]   (Particles having x between -4 and 10)
+            'z' : [0, 100] (Particles having x between 0 and 100)
 
         Returns
         -------
@@ -122,8 +122,8 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         select : dict, optional
             Either None or a dictionary of rules
             to select the particles, of the form
-            'x' : [-4., 10.]   (Particles having x between -4 and 10 microns)
-            'z' : [0, 100] (Particles having x between 0 and 100 microns)
+            'x' : [-4., 10.]   (Particles having x between -4 and 10)
+            'z' : [0, 100] (Particles having x between 0 and 100)
 
         plot : bool, optional
            Whether to plot the requested quantity
@@ -160,12 +160,12 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         if plot:
             check_matplotlib()
             iteration = self.iterations[ self._current_i ]
-            time_fs = 1.e15 * self.t[ self._current_i ]
+            time = self.t[ self._current_i ]
             plt.plot(z_pos, spreads, **kw)
-            plt.title("Slice energy spread at %.1f fs   (iteration %d)"
-                % (time_fs, iteration), fontsize=self.plotter.fontsize)
-            plt.xlabel('$z \;(\mu m)$', fontsize=self.plotter.fontsize)
-            plt.ylabel('$\sigma_\gamma (\Delta_z=%s\mu m)$' % dz,
+            plt.title("Slice energy spread at %.1f s   (iteration %d)"
+                % (time, iteration), fontsize=self.plotter.fontsize)
+            plt.xlabel('$z \;(m)$', fontsize=self.plotter.fontsize)
+            plt.ylabel('$\sigma_\gamma (\Delta_z=%s m)$' % dz,
                        fontsize=self.plotter.fontsize)
         return(spreads, z_pos)
 
@@ -190,8 +190,8 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         select : dict, optional
             Either None or a dictionary of rules
             to select the particles, of the form
-            'x' : [-4., 10.]   (Particles having x between -4 and 10 microns)
-            'z' : [0, 100] (Particles having x between 0 and 100 microns)
+            'x' : [-4., 10.]   (Particles having x between -4 and 10)
+            'z' : [0, 100] (Particles having x between 0 and 100)
 
         Returns
         -------
@@ -227,8 +227,8 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         select : dict, optional
             Either None or a dictionary of rules
             to select the particles, of the form
-            'x' : [-4., 10.]   (Particles having x between -4 and 10 microns)
-            'z' : [0, 100] (Particles having x between 0 and 100 microns)
+            'x' : [-4., 10.]   (Particles having x between -4 and 10)
+            'z' : [0, 100] (Particles having x between 0 and 100)
 
         Returns
         -------
@@ -270,8 +270,8 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         select : dict, optional
             Either None or a dictionary of rules to select the particles,
             of the form:
-            'x' : [-4., 10.]   (Particles having x between -4 and 10 microns);
-            'z' : [0, 100] (Particles having x between 0 and 100 microns).
+            'x' : [-4., 10.]   (Particles having x between -4 and 10);
+            'z' : [0, 100] (Particles having x between 0 and 100).
 
         kind : string, optional
             Kind of emittance to be computed. Can be 'normalized' or 'trace'.
@@ -387,8 +387,8 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         select : dict, optional
             Either None or a dictionary of rules
             to select the particles, of the form
-            'x' : [-4., 10.]   (Particles having x between -4 and 10 microns)
-            'z' : [0, 100] (Particles having x between 0 and 100 microns)
+            'x' : [-4., 10.]   (Particles having x between -4 and 10)
+            'z' : [0, 100] (Particles having x between 0 and 100)
 
         bins : int, optional
             Number of bins along the z-axis in which to calculate the current
@@ -428,11 +428,11 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         if plot:
             check_matplotlib()
             iteration = self.iterations[ self._current_i ]
-            time_fs = 1.e15 * self.t[ self._current_i ]
+            time = self.t[ self._current_i ]
             plt.plot( info.z, current, **kw)
-            plt.title("Current at %.1f fs   (iteration %d)"
-                % (time_fs, iteration ), fontsize=self.plotter.fontsize)
-            plt.xlabel('$z \;(\mu m)$', fontsize=self.plotter.fontsize)
+            plt.title("Current at %.1f s   (iteration %d)"
+                % (time, iteration ), fontsize=self.plotter.fontsize)
+            plt.xlabel('$z \;(m)$', fontsize=self.plotter.fontsize)
             plt.ylabel('$I \;(A)$', fontsize=self.plotter.fontsize)
         # Return the current and bin centers
         return(current, info)
@@ -537,20 +537,20 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         if plot:
             check_matplotlib()
             iteration = self.iterations[ self._current_i ]
-            time_fs = 1.e15 * self.t[ self._current_i ]
+            time = self.t[ self._current_i ]
             if index != 'all':
-                plt.plot( 1.e6 * info.z, envelope, **kw)
+                plt.plot( info.z, envelope, **kw)
                 plt.ylabel('$E_%s \;(V/m)$' % pol,
                            fontsize=self.plotter.fontsize)
             else:
-                plt.imshow( envelope, extent=1.e6 * info.imshow_extent,
+                plt.imshow( envelope, extent=info.imshow_extent,
                             aspect='auto', **kw)
                 plt.colorbar()
-                plt.ylabel('$%s \;(\mu m)$' % pol,
+                plt.ylabel('$%s \;(m)$' % pol,
                             fontsize=self.plotter.fontsize)
-            plt.title("Laser envelope at %.1f fs   (iteration %d)"
-                % (time_fs, iteration ), fontsize=self.plotter.fontsize)
-            plt.xlabel('$z \;(\mu m)$', fontsize=self.plotter.fontsize)
+            plt.title("Laser envelope at %.1f s   (iteration %d)"
+                % (time, iteration ), fontsize=self.plotter.fontsize)
+            plt.xlabel('$z \;(m)$', fontsize=self.plotter.fontsize)
         # Return the result
         return( envelope, info )
 
@@ -744,13 +744,13 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         if plot:
             check_matplotlib()
             iteration = self.iterations[ self._current_i ]
-            time_fs = 1.e15 * self.t[ self._current_i ]
+            time = self.t[ self._current_i ]
             plt.plot( spect_info.omega, spectrum, **kw )
             plt.xlabel('$\omega \; (rad.s^{-1})$',
                        fontsize=self.plotter.fontsize )
             plt.ylabel('Spectrum', fontsize=self.plotter.fontsize )
-            plt.title("Spectrum at %.1f fs   (iteration %d)"
-                % (time_fs, iteration ), fontsize=self.plotter.fontsize)
+            plt.title("Spectrum at %.1f s   (iteration %d)"
+                % (time, iteration ), fontsize=self.plotter.fontsize)
         return( spectrum, spect_info )
 
     def get_a0( self, t=None, iteration=None, pol=None ):
@@ -1038,11 +1038,11 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         if plot:
             check_matplotlib()
             iteration = self.iterations[ self._current_i ]
-            time_fs = 1.e15 * self.t[ self._current_i ]
+            time = self.t[ self._current_i ]
             plt.imshow( spectrogram, extent=info.imshow_extent, aspect='auto',
                         **kw)
-            plt.title("Spectrogram at %.1f fs   (iteration %d)"
-                % (time_fs, iteration ), fontsize=self.plotter.fontsize)
+            plt.title("Spectrogram at %.1f s   (iteration %d)"
+                % (time, iteration ), fontsize=self.plotter.fontsize)
             plt.xlabel('$t \;(s)$', fontsize=self.plotter.fontsize )
             plt.ylabel('$\omega \;(rad.s^{-1})$',
                        fontsize=self.plotter.fontsize )

--- a/opmd_viewer/openpmd_timeseries/data_reader/particle_reader.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/particle_reader.py
@@ -19,8 +19,6 @@ def read_species_data(file_handle, species, record_comp, extensions):
     """
     Extract a given species' record_comp
 
-    In the case of positions, the result is returned in microns
-
     Parameters
     ----------
     file_handle: h5py.File object
@@ -74,11 +72,10 @@ def read_species_data(file_handle, species, record_comp, extensions):
             w = get_data( species_grp[ 'weighting' ] )
             data *= w ** (-weighting_power)
 
-    # - Return positions in microns, with an offset
+    # - Return positions, with an offset
     if record_comp in ['x', 'y', 'z']:
         offset = get_data(species_grp['positionOffset/%s' % record_comp])
         data += offset
-        data *= 1.e6
     # - Return momentum in normalized units
     elif record_comp in ['ux', 'uy', 'uz' ]:
         m = get_data(species_grp['mass'])

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -122,7 +122,6 @@ class OpenPMDTimeSeries(InteractiveViewer):
         If two quantities are requested by the user, this plots
         a 2d histogram of these quantities.
 
-        In the case of positions, the result is returned in microns
         In the case of momenta, the result is returned as:
         - unitless momentum (i.e. gamma*beta) for particles with non-zero mass
         - in kg.m.s^-1 for particles with zero mass
@@ -152,7 +151,7 @@ class OpenPMDTimeSeries(InteractiveViewer):
         select: dict or ParticleTracker object, optional
             - If `select` is a dictionary:
             then it lists a set of rules to select the particles, of the form
-            'x' : [-4., 10.]   (Particles having x between -4 and 10 microns)
+            'x' : [-4., 10.]   (Particles having x between -4 and 10)
             'ux' : [-0.1, 0.1] (Particles having ux between -0.1 and 0.1 mc)
             'uz' : [5., None]  (Particles with uz above 5 mc)
             - If `select` is a ParticleTracker object:

--- a/opmd_viewer/openpmd_timeseries/particle_tracker.py
+++ b/opmd_viewer/openpmd_timeseries/particle_tracker.py
@@ -73,7 +73,7 @@ class ParticleTracker( object ):
         select: dict, optional
             Either None or a dictionary of rules
             to select the particles, of the form
-            'x' : [-4., 10.]  (Particles having x between -4 and 10 microns)
+            'x' : [-4., 10.]  (Particles having x between -4 and 10)
             'ux' : [-0.1, 0.1] (Particles having ux between -0.1 and 0.1 mc)
             'uz' : [5., None]  (Particles with uz above 5 mc)
 

--- a/opmd_viewer/openpmd_timeseries/plotter.py
+++ b/opmd_viewer/openpmd_timeseries/plotter.py
@@ -95,7 +95,7 @@ class Plotter(object):
 
         # Find the iteration and time
         iteration = self.iterations[current_i]
-        time_fs = 1.e15 * self.t[current_i]
+        time = self.t[current_i]
 
         # Check deposition method
         if deposition == 'cic' and not cython_function_available:
@@ -119,8 +119,8 @@ class Plotter(object):
         plt.xlim( hist_range[0] )
         plt.ylim( hist_range[1] )
         plt.xlabel(quantity1, fontsize=self.fontsize)
-        plt.title("%s:   t =  %.0f fs    (iteration %d)"
-                  % (species, time_fs, iteration), fontsize=self.fontsize)
+        plt.title("%s:   t =  %.0f s    (iteration %d)"
+                  % (species, time, iteration), fontsize=self.fontsize)
 
     def hist2d(self, q1, q2, w, quantity1, quantity2, species, current_i,
                 nbins, hist_range, cmap='Blues', vmin=None, vmax=None,
@@ -168,7 +168,7 @@ class Plotter(object):
 
         # Find the iteration and time
         iteration = self.iterations[current_i]
-        time_fs = 1.e15 * self.t[current_i]
+        time = self.t[current_i]
 
         # Check deposition method
         if deposition == 'cic' and not cython_function_available:
@@ -195,8 +195,8 @@ class Plotter(object):
         plt.colorbar()
         plt.xlabel(quantity1, fontsize=self.fontsize)
         plt.ylabel(quantity2, fontsize=self.fontsize)
-        plt.title("%s:   t =  %.1f fs   (iteration %d)"
-                  % (species, time_fs, iteration), fontsize=self.fontsize)
+        plt.title("%s:   t =  %.1f s   (iteration %d)"
+                  % (species, time, iteration), fontsize=self.fontsize)
 
     def show_field_1d( self, F, info, field_label, current_i, plot_range,
                             vmin=None, vmax=None, **kw ):
@@ -226,16 +226,16 @@ class Plotter(object):
 
         # Find the iteration and time
         iteration = self.iterations[current_i]
-        time_fs = 1.e15 * self.t[current_i]
+        time = self.t[current_i]
 
         # Get the title and labels
-        plt.title("%s at %.1f fs   (iteration %d)"
-                % (field_label, time_fs, iteration), fontsize=self.fontsize)
+        plt.title("%s at %.1f s   (iteration %d)" % (field_label,
+                    time, iteration), fontsize=self.fontsize)
 
         # Add the name of the axes
-        plt.xlabel('$%s \;(\mu m)$' % info.axes[0], fontsize=self.fontsize)
-        # Get the x axis in microns
-        xaxis = 1.e6 * getattr( info, info.axes[0] )
+        plt.xlabel('$%s \;(m)$' % info.axes[0], fontsize=self.fontsize)
+        # Get the x axis
+        xaxis = getattr( info, info.axes[0] )
         # Plot the data
         plt.plot( xaxis, F )
         # Get the limits of the plot
@@ -284,33 +284,33 @@ class Plotter(object):
 
         # Find the iteration and time
         iteration = self.iterations[current_i]
-        time_fs = 1.e15 * self.t[current_i]
+        time = self.t[current_i]
 
         # Get the title and labels
         # Cylindrical geometry
         if geometry == "thetaMode":
             mode = str(m)
-            plt.title("%s in the mode %s at %.1f fs   (iteration %d)"
-                      % (field_label, mode, time_fs, iteration),
+            plt.title("%s in the mode %s at %.1f s   (iteration %d)"
+                      % (field_label, mode, time, iteration),
                       fontsize=self.fontsize)
         # 2D Cartesian geometry
         elif geometry == "2dcartesian":
-            plt.title("%s at %.1f fs   (iteration %d)"
-                      % (field_label, time_fs, iteration),
+            plt.title("%s at %.1f s   (iteration %d)"
+                      % (field_label, time, iteration),
                       fontsize=self.fontsize)
         # 3D Cartesian geometry
         elif geometry == "3dcartesian":
             slice_plane = info.axes[0] + '-' + info.axes[1]
-            plt.title("%s sliced in %s at %.1f fs  (iteration %d)"
-                      % (field_label, slice_plane, time_fs, iteration),
+            plt.title("%s sliced in %s at %.1f s  (iteration %d)"
+                      % (field_label, slice_plane, time, iteration),
                       fontsize=self.fontsize)
 
         # Add the name of the axes
-        plt.xlabel('$%s \;(\mu m)$' % info.axes[1], fontsize=self.fontsize)
-        plt.ylabel('$%s \;(\mu m)$' % info.axes[0], fontsize=self.fontsize)
+        plt.xlabel('$%s \;(m)$' % info.axes[1], fontsize=self.fontsize)
+        plt.ylabel('$%s \;(m)$' % info.axes[0], fontsize=self.fontsize)
 
         # Plot the data
-        plt.imshow(F, extent=1.e6 * info.imshow_extent, origin='lower',
+        plt.imshow(F, extent=info.imshow_extent, origin='lower',
                    interpolation='nearest', aspect='auto', **kw)
         plt.colorbar()
 

--- a/opmd_viewer/openpmd_timeseries/utilities.py
+++ b/opmd_viewer/openpmd_timeseries/utilities.py
@@ -74,7 +74,7 @@ def apply_selection(file_handle, data_list, select, species, extensions):
 
     select: dict
         A dictionary of rules to select the particles
-        'x' : [-4., 10.]   (Particles having x between -4 and 10 microns)
+        'x' : [-4., 10.]   (Particles having x between -4 and 10)
         'ux' : [-0.1, 0.1] (Particles having ux between -0.1 and 0.1 mc)
         'uz' : [5., None]  (Particles with uz above 5 mc)
 
@@ -131,7 +131,7 @@ def fit_bins_to_grid( hist_size, grid_size, grid_range ):
     grid_size: integer
         The number of cells in the grid
 
-    grid_range: list of floats (in meters)
+    grid_range: list of floats (in)
         The extent of the grid
 
     Returns:
@@ -139,7 +139,7 @@ def fit_bins_to_grid( hist_size, grid_size, grid_range ):
     hist_size: integer
         The new number of bins
 
-    hist_range: list of floats (in microns)
+    hist_range: list of floats
         The new range of the histogram
     """
     # The new histogram range is the same as the grid range
@@ -160,9 +160,5 @@ def fit_bins_to_grid( hist_size, grid_size, grid_range ):
     # Get the corresponding new number of bins, and the new range
     hist_size = int( ( hist_range[1] - hist_range[0] ) / hist_spacing )
     hist_range[1] = hist_range[0] + hist_size * hist_spacing
-
-    # Convert the range to microns (since this is how particle positions
-    # are returned in the openPMD-viewer)
-    hist_range = [ 1.e6 * hist_range[0], 1.e6 * hist_range[1] ]
 
     return( hist_size, hist_range )


### PR DESCRIPTION
A long-requested feature of `openPMD-viewer` is to have consistent units throughout all the function calls (e.g. meters and seconds everywhere, instead of the occasional microns and femtoseconds).

This change would go into the upcoming openPMD-viewer 1.0, which has a breaking API change.

Note that this conversion makes plotting less readable (because matplotlib typically prints 1.e-6 as 0.000001). However, I will address this issue in a later pull request.