### PR TITLE
Switch from pep8 to pcodestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,14 +36,14 @@ install:
   - pip install matplotlib
   - python setup.py install
   - pip install wget
-  - pip install pyflakes pep8 jupyter
+  - pip install pyflakes pycodestyle jupyter
 
 before_script :
   # static code analysis
   #   pyflakes: mainly warnings, unused code, etc.
   - python -m pyflakes opmd_viewer
   #   pep8: style only, enforce PEP 8
-  - python -m pep8 --ignore=E201,E202,E122,E127,E128,E131 opmd_viewer
+  - python -m pycodestyle --ignore=E201,E202,E122,E127,E128,E131 opmd_viewer
 
 script:
   - "python setup.py test"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,12 +47,12 @@ git pull git@github.com:openPMD/openPMD-viewer.git dev
 
 - Test and check your code:
   - Use [pyflakes](https://pypi.python.org/pypi/pyflakes) and 
-[pep8](https://pypi.python.org/pypi/pep8) to detect any potential bug, and to 
+[pycodestyle](https://pypi.org/project/pycodestyle/) to detect any potential bug, and to 
 ensure that your code complies with some standard style conventions.
   ```
   cd openPMD-viewer/
   pyflakes opmd_viewer
-  pep8 --ignore=E201,E202,E122,E127,E128,E131 opmd_viewer
+  pycodestyle --ignore=E201,E202,E122,E127,E128,E131 opmd_viewer
   ```
   - Make sure that the tests pass (please install `wget` and `jupyter` before running the tests: `pip install wget jupyter`)
   ```

--- a/opmd_viewer/openpmd_timeseries/particle_tracker.py
+++ b/opmd_viewer/openpmd_timeseries/particle_tracker.py
@@ -281,6 +281,7 @@ def extract_indices_python( original_indices, selected_indices,
 
     return( i_fill )
 
+
 # The functions `extract_indices_python` and `extract_indices_cython`
 # perform the same operations, but the cython version is much faster
 # since it is compiled


### PR DESCRIPTION
`pep8` currently prints the following message:
```
pep8 has been renamed to pycodestyle (GitHub issue #466)
Use of the pep8 tool will be removed in a future release.
Please install and use `pycodestyle` instead.
```

This PR switches from `pep8` to `pycodestyle`.