### PR TITLE
Better formatting for axes ticks

### DIFF
--- a/opmd_viewer/openpmd_timeseries/plotter.py
+++ b/opmd_viewer/openpmd_timeseries/plotter.py
@@ -9,6 +9,7 @@ Author: Remi Lehe
 License: 3-Clause-BSD-LBNL
 """
 import numpy as np
+import math
 try:
     import warnings
     import matplotlib
@@ -31,7 +32,7 @@ if matplotlib_installed:
         # TODO
         """
         def __init__( self, *args, **kwargs ):
-            mticker.ScalarFormatter.__init__( self, *args, **kwargs )
+            ScalarFormatter.__init__( self, *args, **kwargs )
             self.set_scientific(False)
             self._offset_threshold = 2
 
@@ -156,8 +157,8 @@ class Plotter(object):
         bin_size = (hist_range[0][1] - hist_range[0][0]) / nbins
         bin_coords = hist_range[0][0] + bin_size * ( 0.5 + np.arange(nbins) )
         plt.bar( bin_coords, binned_data, width=bin_size, **kw )
-        plt.set_xlim( hist_range[0] )
-        plt.set_ylim( hist_range[1] )
+        plt.xlim( hist_range[0] )
+        plt.ylim( hist_range[1] )
         plt.xlabel(quantity1, fontsize=self.fontsize)
         plt.title("%s:   t =  %.0f s    (iteration %d)"
                   % (species, time, iteration), fontsize=self.fontsize)


### PR DESCRIPTION
The default matplotlib formatter for axes has one shortcoming: numbers on the order of 1e-6 are printed as 0.000001. With the recent PR #211 , this becomes a problem because, for e.g. laser plasma acceleration, most distances are of this order of magnitude.

Consider for instance this example:
```
vals = 1. + 3.e-6*np.random.rand(400)
plt.hist( vals )
```
Which produces this result, where labels are quite hard to read.
<img width="375" alt="screen shot 2018-06-07 at 2 30 38 pm" src="https://user-images.githubusercontent.com/6685781/41127341-66a201a6-6a5f-11e8-9e87-f40d76944eb9.png">

Note however that the default formatter has a nice property: any constant offset is detected and printed on the side of the axis (`+1` in this case.)

It would be nice to retain the above property, while having a better way to print numbers on the order of 1e-6.

This PR addresses the issue by creating a subclass of the default matplotlib formatter, which retains the offset, but prints the numbers in scientific format, with exponents that are multiples of 3. This helps in quickly identifying the closest units (e.g. microns, nanometers, etc.)

In the above example, one gets
<img width="360" alt="screen shot 2018-06-07 at 2 34 45 pm" src="https://user-images.githubusercontent.com/6685781/41127491-f4b0c6f8-6a5f-11e8-8a2d-86e9737c248b.png">