### PR TITLE
Correct position of slice for cylindrical data

### DIFF
--- a/opmd_viewer/openpmd_timeseries/data_reader/field_reader.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/field_reader.py
@@ -192,7 +192,7 @@ def read_field_circ( filename, field_path, slicing, slicing_dir, m=0,
         F_total[:Nr, :] = (-1) ** m * F[::-1, :]
 
     axis_labels = ['r', 'z']
-    shape = [Nr, Nz]
+    shape = [2 * Nr, Nz]
     grid_spacing = list( group.attrs['gridSpacing'] )
     global_offset = list( group.attrs['gridGlobalOffset'] )
 


### PR DESCRIPTION
With the new slicing code (see PR #195 ), there was a small error in the slicing of cylindrical data.

For instance, here is the 2D map of the fields:
<img width="451" alt="screen shot 2018-06-09 at 8 11 55 am" src="https://user-images.githubusercontent.com/6685781/41193134-3e57742e-6bbd-11e8-9170-da24de57e282.png">

With the previous code, slicing at r=0 (`slicing_dir='r'`, `slicing=0`) produced:
<img width="452" alt="screen shot 2018-06-09 at 8 17 33 am" src="https://user-images.githubusercontent.com/6685781/41193164-9bb7329e-6bbd-11e8-80f3-8462aa9df306.png">
which is obviously not the value at r=0. The reason is that the slice index was miscalculated due to a wrong value for the shape.

With this PR, slicing produces the correct value:
<img width="457" alt="screen shot 2018-06-09 at 8 16 54 am" src="https://user-images.githubusercontent.com/6685781/41193150-7fd7e244-6bbd-11e8-91eb-07b099669c44.png">
