### PR TITLE
Improve printed time in plot title

### DIFF
--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -162,7 +162,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             iteration = self.iterations[ self._current_i ]
             time_s = self.t[ self._current_i ]
             plt.plot(z_pos, spreads, **kw)
-            plt.title("Slice energy spread at %.1f s   (iteration %d)"
+            plt.title("Slice energy spread at %.2e s   (iteration %d)"
                 % (time_s, iteration), fontsize=self.plotter.fontsize)
             plt.xlabel('$z \;(m)$', fontsize=self.plotter.fontsize)
             plt.ylabel('$\sigma_\gamma (\Delta_z=%s m)$' % dz,
@@ -430,7 +430,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             iteration = self.iterations[ self._current_i ]
             time_s = self.t[ self._current_i ]
             plt.plot( info.z, current, **kw)
-            plt.title("Current at %.1f s   (iteration %d)"
+            plt.title("Current at %.2e s   (iteration %d)"
                 % (time_s, iteration ), fontsize=self.plotter.fontsize)
             plt.xlabel('$z \;(m)$', fontsize=self.plotter.fontsize)
             plt.ylabel('$I \;(A)$', fontsize=self.plotter.fontsize)
@@ -548,7 +548,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
                 plt.colorbar()
                 plt.ylabel('$%s \;(m)$' % pol,
                             fontsize=self.plotter.fontsize)
-            plt.title("Laser envelope at %.1f s   (iteration %d)"
+            plt.title("Laser envelope at %.2e s   (iteration %d)"
                 % (time_s, iteration ), fontsize=self.plotter.fontsize)
             plt.xlabel('$z \;(m)$', fontsize=self.plotter.fontsize)
         # Return the result
@@ -749,7 +749,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             plt.xlabel('$\omega \; (rad.s^{-1})$',
                        fontsize=self.plotter.fontsize )
             plt.ylabel('Spectrum', fontsize=self.plotter.fontsize )
-            plt.title("Spectrum at %.1f s   (iteration %d)"
+            plt.title("Spectrum at %.2e s   (iteration %d)"
                 % (time_s, iteration ), fontsize=self.plotter.fontsize)
         return( spectrum, spect_info )
 
@@ -1041,7 +1041,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             time_s = self.t[ self._current_i ]
             plt.imshow( spectrogram, extent=info.imshow_extent, aspect='auto',
                         **kw)
-            plt.title("Spectrogram at %.1f s   (iteration %d)"
+            plt.title("Spectrogram at %.2e s   (iteration %d)"
                 % (time_s, iteration ), fontsize=self.plotter.fontsize)
             plt.xlabel('$t \;(s)$', fontsize=self.plotter.fontsize )
             plt.ylabel('$\omega \;(rad.s^{-1})$',

--- a/opmd_viewer/openpmd_timeseries/plotter.py
+++ b/opmd_viewer/openpmd_timeseries/plotter.py
@@ -171,7 +171,7 @@ class Plotter(object):
         plt.xlim( hist_range[0] )
         plt.ylim( hist_range[1] )
         plt.xlabel(quantity1, fontsize=self.fontsize)
-        plt.title("%s:   t =  %.0f s    (iteration %d)"
+        plt.title("%s:   t =  %.2e s    (iteration %d)"
                   % (species, time, iteration), fontsize=self.fontsize)
         # Format the ticks
         ax = plt.gca()
@@ -251,7 +251,7 @@ class Plotter(object):
         plt.colorbar()
         plt.xlabel(quantity1, fontsize=self.fontsize)
         plt.ylabel(quantity2, fontsize=self.fontsize)
-        plt.title("%s:   t =  %.1f s   (iteration %d)"
+        plt.title("%s:   t =  %.2e s   (iteration %d)"
                   % (species, time, iteration), fontsize=self.fontsize)
         # Format the ticks
         ax = plt.gca()
@@ -289,7 +289,7 @@ class Plotter(object):
         time = self.t[current_i]
 
         # Get the title and labels
-        plt.title("%s at %.1f s   (iteration %d)" % (field_label,
+        plt.title("%s at %.2e s   (iteration %d)" % (field_label,
                     time, iteration), fontsize=self.fontsize)
 
         # Add the name of the axes
@@ -354,19 +354,13 @@ class Plotter(object):
         # Cylindrical geometry
         if geometry == "thetaMode":
             mode = str(m)
-            plt.title("%s in the mode %s at %.1f s   (iteration %d)"
+            plt.title("%s in the mode %s at %.2e s   (iteration %d)"
                       % (field_label, mode, time, iteration),
                       fontsize=self.fontsize)
         # 2D Cartesian geometry
-        elif geometry == "2dcartesian":
-            plt.title("%s at %.1f s   (iteration %d)"
+        else:
+            plt.title("%s at %.2e s   (iteration %d)"
                       % (field_label, time, iteration),
-                      fontsize=self.fontsize)
-        # 3D Cartesian geometry
-        elif geometry == "3dcartesian":
-            slice_plane = info.axes[0] + '-' + info.axes[1]
-            plt.title("%s sliced in %s at %.1f s  (iteration %d)"
-                      % (field_label, slice_plane, time, iteration),
                       fontsize=self.fontsize)
 
         # Add the name of the axes


### PR DESCRIPTION
Now that (on the branch `upcoming-1.0`) the time in seconds everywhere, the title on the plots shows `t = 0.0 s` all the time, because the number is too small (~1.e-15) to be printed with `%f`. Printing with `%e` solves the issue.