### PR TITLE
Allow slice emittance calculation along arbitrary coordinates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ before_install:
 
 # Install packages
 install:
-  - conda install --yes numpy >=1.10
-  - conda install --yes numpy cython numpy scipy h5py
+  - pip install numpy
+  - conda install --yes cython  scipy h5py
   - pip install matplotlib
   - python setup.py install
   - pip install wget

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,7 @@ before_install:
 
 # Install packages
 install:
-  - conda install --yes numpy=1.15.1
-  - conda install --yes cython
-  - conda install --yes scipy
-  - conda install --yes h5py
+  - conda install --yes cython numpy scipy h5py
   - pip install matplotlib
   - python setup.py install
   - pip install wget

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 
 # Install packages
 install:
-  - conda install --yes cython numpy scipy h5py
+  - conda install --yes cython numpy scipy h5py libgfortran
   - pip install matplotlib
   - python setup.py install
   - pip install wget

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
       wget https://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -O miniconda.sh;
     fi
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+      wget http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
   - chmod +x miniconda.sh
   - ./miniconda.sh -b

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ before_install:
 
 # Install packages
 install:
-  - conda install numpy
-  - conda install --yes cython numpy scipy h5py
+  - conda install --yes numpy cython numpy scipy h5py
+  - conda update --yes numpy
   - pip install matplotlib
   - python setup.py install
   - pip install wget

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,14 +36,14 @@ install:
   - pip install matplotlib
   - python setup.py install
   - pip install wget
-  - pip install pyflakes pep8 jupyter
+  - pip install pyflakes pycodestyle jupyter
 
 before_script :
   # static code analysis
   #   pyflakes: mainly warnings, unused code, etc.
   - python -m pyflakes opmd_viewer
   #   pep8: style only, enforce PEP 8
-  - python -m pep8 --ignore=E201,E202,E122,E127,E128,E131 opmd_viewer
+  - python -m pycodestyle --ignore=E201,E202,E122,E127,E128,E131,W605 opmd_viewer
 
 script:
   - "python setup.py test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,8 @@ before_install:
 
 # Install packages
 install:
-  - conda install --yes cython numpy scipy h5py libgfortran
+  -conda install numpy
+  - conda install --yes cython numpy scipy h5py
   - pip install matplotlib
   - python setup.py install
   - pip install wget

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 
 # Install packages
 install:
-  - conda install --yes numpy
+  - conda install --yes numpy=1.15.1
   - conda install --yes cython
   - conda install --yes scipy
   - conda install --yes h5py

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 
 # Install packages
 install:
-  -conda install numpy
+  - conda install numpy
   - conda install --yes cython numpy scipy h5py
   - pip install matplotlib
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ before_install:
 
 # Install packages
 install:
+  - conda install --yes numpy >=1.10
   - conda install --yes numpy cython numpy scipy h5py
-  - conda update --yes numpy
   - pip install matplotlib
   - python setup.py install
   - pip install wget

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,10 @@ before_install:
 
 # Install packages
 install:
-  - pip install numpy
-  - conda install --yes cython  scipy h5py
+  - conda install --yes numpy
+  - conda install --yes cython
+  - conda install --yes scipy
+  - conda install --yes h5py
   - pip install matplotlib
   - python setup.py install
   - pip install wget

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,12 +47,12 @@ git pull git@github.com:openPMD/openPMD-viewer.git dev
 
 - Test and check your code:
   - Use [pyflakes](https://pypi.python.org/pypi/pyflakes) and 
-[pep8](https://pypi.python.org/pypi/pep8) to detect any potential bug, and to 
+[pycodestyle](https://pypi.python.org/pypi/pycodestyle) to detect any potential bug, and to 
 ensure that your code complies with some standard style conventions.
   ```
   cd openPMD-viewer/
   pyflakes opmd_viewer
-  pep8 --ignore=E201,E202,E122,E127,E128,E131 opmd_viewer
+  pycodestyle --ignore=E201,E202,E122,E127,E128,E131,W605 opmd_viewer
   ```
   - Make sure that the tests pass (please install `wget` and `jupyter` before running the tests: `pip install wget jupyter`)
   ```

--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -292,9 +292,11 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             Needs to be in the openPMD dataset. Default is 'z' i.e. silcing
             along the longitudinal coordinate of the bunch.
 
-        slice_range : float (in meters), optional
+        slice_range : float, optional
             Range in 'slice_coordinate', used to calculate slice positions
-            when nslices>1.
+            when nslices>1. Slice emittance is calculated from
+            mean(slice_coordinate) - slice_range/2 to
+            mean(slice_coordinate) + slice_range/2
             By default, it is 4 times the standard deviation
             of 'slice_coordinate'.
 

--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -374,9 +374,9 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             if description == 'all-slices':
                 # Info object with central position of the slices
                 info = FieldMetaInformation( {0: slice_coordinate},
-                            (nslices,), grid_spacing=(slice_range / nslices, ),
-                            grid_unitSI=1, position=(0,),
-                            global_offset=(slice_centers[0],))
+                    (nslices,), grid_spacing=(slice_range / nslices, ),
+                    grid_unitSI=1, position=(0,),
+                    global_offset=(slice_centers[0],))
                 return (emit_slice_x, emit_slice_y,
                         slice_weights, info)
             else:

--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -248,7 +248,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
 
     def get_emittance(self, t=None, iteration=None, species=None,
                       select=None, kind='normalized', description='projected',
-                      nslices=0, beam_length=None):
+                      nslices=0, slice_coordinate='z', slice_range=None):
         """
         Calculate the RMS emittance.
         (See K Floetmann: Some basic features of beam emittance. PRSTAB 2003)
@@ -287,9 +287,16 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             Number of slices to compute slice emittance. Required if
             description='slice-average' or 'all-slices'.
 
-        beam_length : float (in meters), optional
-            Beam length, used to calculate slice positions when nslices>1.
-            By default, it is 4 times the standard deviation in z.
+        slice_coordinate: string, optional
+            Phase space coordinate in which to calculate the slice emittance.
+            Needs to be in the openPMD dataset. Default is 'z' i.e. silcing
+            along the longitudinal coordinate of the bunch.
+
+        slice_range : float (in meters), optional
+            Range in 'slice_coordinate', used to calculate slice positions
+            when nslices>1.
+            By default, it is 4 times the standard deviation
+            of 'slice_coordinate'.
 
         Returns
         -------
@@ -302,13 +309,14 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             - A 1d array with beam emittance in the y plane
               (pi m rad) for each slice
             - A 1d array with number of electrons in each slice
-            - A 1d array with slice centers
+            - A FieldMetaInformation object with the slice centers along
+              'slice_coordinate'
         """
         if kind not in ['normalized', 'trace']:
             raise ValueError('Argument `kind` not recognized.')
         if description not in ['projected', 'slice-averaged', 'all-slices']:
             raise ValueError('Argument `description` not recognized.')
-        # Wheter to compute slice emittance
+        # Whether to compute slice emittance
         do_slice_emittance = ( description in ['slice-averaged',
                                                'all-slices'] )
         if do_slice_emittance and not nslices > 0:
@@ -327,36 +335,48 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         if kind == 'trace':
             ux = ux / uz
             uy = uy / uz
-
+        # Again get data over which the slice emittance is calculated
+        slice_data, w = self.get_particle(
+            var_list=[slice_coordinate, 'w'], t=t,
+            iteration=iteration, species=species, select=select )
+        # Calculate slice emittance
         if do_slice_emittance:
             # Get slice locations
-            zavg = w_ave(z, w)
-            z = z - zavg
-            if beam_length is None:
-                std = w_std(z, w)
-                beam_length = 4 * std
-            bins = np.linspace( -beam_length / 2, beam_length / 2, nslices )
-            binwidth = .5 * bins[1] - .5 * bins[0]
-            slice_centers = bins + .5 * binwidth
+            beam_ave = w_ave(slice_data, w)
+            # Center
+            # z = z - zavg
+            if slice_range is None:
+                std = w_std(slice_data, w)
+                slice_range = 4 * std
+            bins = np.linspace( beam_ave - slice_range / 2,
+                                beam_ave + slice_range / 2, nslices + 1 )
+            binwidth = bins[1] - bins[0]
+            slice_centers = bins[:-1] + .5 * binwidth
             # Initialize slice emittance arrays
-            emit_slice_x = np.zeros(len(bins[:-1]))
-            emit_slice_y = np.zeros(len(bins[:-1]))
-            slice_weights = np.zeros(len(bins[:-1]))
+            emit_slice_x = np.zeros(len(slice_centers))
+            emit_slice_y = np.zeros(len(slice_centers))
+            slice_weights = np.zeros(len(slice_centers))
             # Loop over slices
-            for count, leftedge in enumerate(bins[:-1]):
+            for i in range(nslices):
                 # Get emittance in this slice
-                current_slice = (np.abs(z - slice_centers[count]) <= binwidth)
-                slice_weights[count] = np.sum(w[current_slice])
-                if slice_weights[count] > 0:
+                current_slice = np.logical_and((slice_data < bins[i + 1]),
+                                               (slice_data > bins[i]))
+                slice_weights[i] = np.sum(w[current_slice])
+                if slice_weights[i] > 0:
                     emit_x, emit_y = emittance_from_coord(
                         x[current_slice], y[current_slice],
                         ux[current_slice], uy[current_slice],
                         w[current_slice])
-                    emit_slice_x[count] = emit_x
-                    emit_slice_y[count] = emit_y
+                    emit_slice_x[i] = emit_x
+                    emit_slice_y[i] = emit_y
             if description == 'all-slices':
+                # Info object with central position of the slices
+                info = FieldMetaInformation( {0: slice_coordinate},
+                            (nslices,), grid_spacing=(slice_range / nslices, ),
+                            grid_unitSI=1, position=(0,),
+                            global_offset=(slice_centers[0],))
                 return (emit_slice_x, emit_slice_y,
-                    slice_weights, slice_centers)
+                        slice_weights, info)
             else:
                 emit_x = w_ave(emit_slice_x, slice_weights)
                 emit_y = w_ave(emit_slice_y, slice_weights)

--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -312,8 +312,8 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         do_slice_emittance = ( description in ['slice-averaged',
                                                'all-slices'] )
         if do_slice_emittance and not nslices > 0:
-            raise ValueError('nslices must be given if `description`=' +
-                             description + '.')
+            raise ValueError(
+                'nslices must be given if `description`=' + description + '.')
         # Get particle data
         x, y, z, ux, uy, uz, w = self.get_particle(
             var_list=['x', 'y', 'z', 'ux', 'uy', 'uz', 'w'], t=t,
@@ -345,8 +345,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             # Loop over slices
             for count, leftedge in enumerate(bins[:-1]):
                 # Get emittance in this slice
-                current_slice = ( np.abs( z - slice_centers[count] ) <=
-                    binwidth )
+                current_slice = (np.abs(z - slice_centers[count]) <= binwidth)
                 slice_weights[count] = np.sum(w[current_slice])
                 if slice_weights[count] > 0:
                     emit_x, emit_y = emittance_from_coord(

--- a/opmd_viewer/openpmd_timeseries/particle_tracker.py
+++ b/opmd_viewer/openpmd_timeseries/particle_tracker.py
@@ -281,6 +281,7 @@ def extract_indices_python( original_indices, selected_indices,
 
     return( i_fill )
 
+
 # The functions `extract_indices_python` and `extract_indices_cython`
 # perform the same operations, but the cython version is much faster
 # since it is compiled


### PR DESCRIPTION
Often it can be useful to calculate the slice emittance for along another coordinate than z. I changed the method so that now all particle properties can be used for slicing e.g. to calculate the energy (actually uz) dependent emittance. 

There are a few API breaking changes that we would have to decide on (they can easily be reversed)

* the input argument beam_length has now the more general name slice_range
* the slice centers are returned as a FieldMetaInformation object 