### PR TITLE
Upgrade pep8 => pycodestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,14 +36,14 @@ install:
   - pip install matplotlib
   - python setup.py install
   - pip install wget
-  - pip install pyflakes pep8 jupyter
+  - pip install pyflakes pycodestyle jupyter
 
 before_script :
   # static code analysis
   #   pyflakes: mainly warnings, unused code, etc.
   - python -m pyflakes opmd_viewer
   #   pep8: style only, enforce PEP 8
-  - python -m pep8 --ignore=E201,E202,E122,E127,E128,E131 opmd_viewer
+  - python -m pycodestyle --ignore=E201,E202,E122,E127,E128,E131,W605 opmd_viewer
 
 script:
   - "python setup.py test"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,12 +47,12 @@ git pull git@github.com:openPMD/openPMD-viewer.git dev
 
 - Test and check your code:
   - Use [pyflakes](https://pypi.python.org/pypi/pyflakes) and 
-[pep8](https://pypi.python.org/pypi/pep8) to detect any potential bug, and to 
+[pycodestyle](https://pypi.python.org/pypi/pycodestyle) to detect any potential bug, and to 
 ensure that your code complies with some standard style conventions.
   ```
   cd openPMD-viewer/
   pyflakes opmd_viewer
-  pep8 --ignore=E201,E202,E122,E127,E128,E131 opmd_viewer
+  pycodestyle --ignore=E201,E202,E122,E127,E128,E131,W605 opmd_viewer
   ```
   - Make sure that the tests pass (please install `wget` and `jupyter` before running the tests: `pip install wget jupyter`)
   ```

--- a/opmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/opmd_viewer/addons/pic/lpa_diagnostics.py
@@ -312,8 +312,8 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         do_slice_emittance = ( description in ['slice-averaged',
                                                'all-slices'] )
         if do_slice_emittance and not nslices > 0:
-            raise ValueError('nslices must be given if `description`=' +
-                             description + '.')
+            raise ValueError(
+                'nslices must be given if `description`=' + description + '.')
         # Get particle data
         x, y, z, ux, uy, uz, w = self.get_particle(
             var_list=['x', 'y', 'z', 'ux', 'uy', 'uz', 'w'], t=t,
@@ -345,8 +345,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             # Loop over slices
             for count, leftedge in enumerate(bins[:-1]):
                 # Get emittance in this slice
-                current_slice = ( np.abs( z - slice_centers[count] ) <=
-                    binwidth )
+                current_slice = (np.abs(z - slice_centers[count]) <= binwidth)
                 slice_weights[count] = np.sum(w[current_slice])
                 if slice_weights[count] > 0:
                     emit_x, emit_y = emittance_from_coord(

--- a/opmd_viewer/openpmd_timeseries/particle_tracker.py
+++ b/opmd_viewer/openpmd_timeseries/particle_tracker.py
@@ -281,6 +281,7 @@ def extract_indices_python( original_indices, selected_indices,
 
     return( i_fill )
 
+
 # The functions `extract_indices_python` and `extract_indices_cython`
 # perform the same operations, but the cython version is much faster
 # since it is compiled


### PR DESCRIPTION
It seems that the automated tests fail on the `dev` branch because `pep8` is deprecated. This PR should fix the issue.