### PR TITLE
Change miniconda download path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
       wget https://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -O miniconda.sh;
     fi
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+      wget http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
   - chmod +x miniconda.sh
   - ./miniconda.sh -b


### PR DESCRIPTION
Currently, http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh links to an old version of miniconda which leads to an old/incompatible version of numba being installed during the TravisCI build. This PR fixes the problem for the moment.