### PR TITLE
Fix slider when using Jupyterlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ distribution](https://www.continuum.io/downloads), and then type
 ```
 conda install -c rlehe openpmd_viewer
 ```
+If you are using JupyterLab, please also install the `jupyter-matplotlib`
+extension (See installation instructions
+[here](https://github.com/matplotlib/jupyter-matplotlib)).
 
 #### Installation with pip
 

--- a/opmd_viewer/notebook_starter/Template_notebook.ipynb
+++ b/opmd_viewer/notebook_starter/Template_notebook.ipynb
@@ -18,6 +18,7 @@
     "import numpy as np\n",
     "%matplotlib notebook\n",
     "# or `%matplotlib inline` for non-interactive plots\n",
+    "# or `%matplotlib widget` when using JupyterLab (github.com/matplotlib/jupyter-matplotlib)\n",
     "import matplotlib.pyplot as plt\n",
     "from opmd_viewer import OpenPMDTimeSeries"
    ]

--- a/opmd_viewer/openpmd_timeseries/interactive.py
+++ b/opmd_viewer/openpmd_timeseries/interactive.py
@@ -501,6 +501,22 @@ class InteractiveViewer(object):
         elif self.avail_fields is None:
             display(container_ptcl)
 
+        # When using %matplotlib widget, display the figures at the end
+        if 'ipympl' in matplotlib.get_backend():
+            # Disable interactive mode
+            # This prevents the notebook from showing the figure
+            # when calling `plt.figure` (unreliable with `%matplotlib widget`)
+            # and we use `display` instead.
+            plt.ioff()
+            if self.avail_fields is not None:
+                fig = plt.figure( fld_figure_button.value )
+                display(fig.canvas)
+            if self.avail_species is not None:
+                fig = plt.figure( ptcl_figure_button.value )
+                display(fig.canvas)
+            # Enable interactive mode again
+            plt.ion()
+
 
 def convert_to_int(m):
     """

--- a/tutorials/3_Introduction-to-the-GUI.ipynb
+++ b/tutorials/3_Introduction-to-the-GUI.ipynb
@@ -54,7 +54,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n"
+    "%matplotlib notebook\n",
     "# Use `%matplotlib widget` when using JupyterLab"
    ]
   },

--- a/tutorials/3_Introduction-to-the-GUI.ipynb
+++ b/tutorials/3_Introduction-to-the-GUI.ipynb
@@ -54,7 +54,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook"
+    "%matplotlib notebook\n"
+    "# Use `%matplotlib widget` when using JupyterLab"
    ]
   },
   {


### PR DESCRIPTION
This pull request fixes the slider when using JupyterLab.

The issue was that JupyterLab does not support the `%matplotlib notebook` magic. Instead JupyterLab uses the `%matplotlib widget` magic (which requires the [jupyter-matplotlib extension](https://github.com/matplotlib/jupyter-matplotlib)).

However, the rules that determines whether a figure will show up in the notebook are different with `%matplotlib widget` (namely, the figure will only show up if this figure is created for the first time. In other words, running the cell `plt.figure(4)` will show figure number 4 only the first time that this cell is run ; later execution will not show the figure).
These different rules meant that the slider was not showing the figures when using `%matplotlib widget`. This was fixed by including an explicit `display` command.