### PR TITLE
Prevent error in histogram for arrays with single value

### DIFF
--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -302,8 +302,12 @@ class OpenPMDTimeSeries(InteractiveViewer):
                         (plot_range[i_data][1] is not None):
                     hist_range[i_data] = plot_range[i_data]
                 # Else use min and max of data
-                elif len(data) != 0:
+                elif len(data) != 0 and not np.all(data==0):
                     hist_range[i_data] = [ data.min(), data.max() ]
+                    # Avoid error when the min and max are equal
+                    if hist_range[i_data][0] == hist_range[i_data][1]:
+                        hist_range[i_data][0] *= 0.99
+                        hist_range[i_data][1] *= 1.01
                 else:
                     hist_range[i_data] = [ -1., 1. ]
             hist_bins = [ nbins for i_data in range(len(data_list)) ]

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -297,19 +297,25 @@ class OpenPMDTimeSeries(InteractiveViewer):
             hist_range = [[None, None], [None, None]]
             for i_data in range(len(data_list)):
                 data = data_list[i_data]
+
                 # Check if the user specified a value
                 if (plot_range[i_data][0] is not None) and \
                         (plot_range[i_data][1] is not None):
                     hist_range[i_data] = plot_range[i_data]
                 # Else use min and max of data
-                elif len(data) != 0 and not np.all(data == 0):
+                elif len(data) != 0:
                     hist_range[i_data] = [ data.min(), data.max() ]
-                    # Avoid error when the min and max are equal
-                    if hist_range[i_data][0] == hist_range[i_data][1]:
-                        hist_range[i_data][0] *= 0.99
-                        hist_range[i_data][1] *= 1.01
                 else:
                     hist_range[i_data] = [ -1., 1. ]
+
+                # Avoid error when the min and max are equal
+                if hist_range[i_data][0] == hist_range[i_data][1]:
+                    if hist_range[i_data][0] == 0:
+                        hist_range[i_data] = [ -1., 1. ]
+                    else:
+                        hist_range[i_data][0] *= 0.99
+                        hist_range[i_data][1] *= 1.01
+
             hist_bins = [ nbins for i_data in range(len(data_list)) ]
             # - Then, if required by the user, modify this values by
             #   fitting them to the spatial grid

--- a/opmd_viewer/openpmd_timeseries/main.py
+++ b/opmd_viewer/openpmd_timeseries/main.py
@@ -302,7 +302,7 @@ class OpenPMDTimeSeries(InteractiveViewer):
                         (plot_range[i_data][1] is not None):
                     hist_range[i_data] = plot_range[i_data]
                 # Else use min and max of data
-                elif len(data) != 0 and not np.all(data==0):
+                elif len(data) != 0 and not np.all(data == 0):
                     hist_range[i_data] = [ data.min(), data.max() ]
                     # Avoid error when the min and max are equal
                     if hist_range[i_data][0] == hist_range[i_data][1]:


### PR DESCRIPTION
Close #226 For the histogram plots, openPMD-viewer tries to automatically calculate the min and max of the histogram from the values of the array. 

However, for arrays in which all elements have the same values, this typically results in a `ZeroDivisionError` when performing the histograms (because the histogram cell size is 0).

This PR avoids this error by explicitly setting the min and max of the histogram, in the case of a constant array.