### PR TITLE
Remove pep8 checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,14 +36,12 @@ install:
   - pip install matplotlib
   - python setup.py install
   - pip install wget
-  - pip install pyflakes pycodestyle jupyter pytest
+  - pip install pyflakes jupyter pytest
 
 before_script :
   # static code analysis
   #   pyflakes: mainly warnings, unused code, etc.
   - python -m pyflakes opmd_viewer
-  #   pep8: style only, enforce PEP 8
-  - python -m pycodestyle --ignore=E201,E202,E122,E127,E128,E131,W605 opmd_viewer
 
 script:
   - "python setup.py test"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 
 In order to contribute, please fork the [main repository](https://github.com/openPMD/openPMD-viewer):
 
-- Click 'Fork' on the page of the main repository, in order to create a personal copy of this repository on your Github account. 
+- Click 'Fork' on the page of the main repository, in order to create a personal copy of this repository on your Github account.
 
 - Clone this copy to your local machine:
 ```
@@ -46,13 +46,10 @@ git pull git@github.com:openPMD/openPMD-viewer.git dev
 ```
 
 - Test and check your code:
-  - Use [pyflakes](https://pypi.python.org/pypi/pyflakes) and 
-[pycodestyle](https://pypi.python.org/pypi/pycodestyle) to detect any potential bug, and to 
-ensure that your code complies with some standard style conventions.
+  - Use [pyflakes](https://pypi.python.org/pypi/pyflakes) to detect any potential bug.
   ```
   cd openPMD-viewer/
   pyflakes opmd_viewer
-  pycodestyle --ignore=E201,E202,E122,E127,E128,E131,W605 opmd_viewer
   ```
   - Make sure that the tests pass (please install `wget` and `jupyter` before running the tests: `pip install wget jupyter`)
   ```
@@ -101,7 +98,7 @@ def get_data( dset, i_slice=None, pos_slice=None ) :
 
     i_slice: int, optional
        The index of the slice to be taken
-    
+
     pos_slice: int, optional
        The position at which to slice the array
        When None, no slice is performed


### PR DESCRIPTION
Although checking PEP8 is useful in some cases, my impression is that, in the case of openPMD-viewer, this slows down code development because of minor styling conventions (e.g. spaces between operators, etc.)

I would be in favor of removing the PEP8 checks.