### PR TITLE
Drop python 3.4 support in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
       python: "3.5"
     - os: linux
       python: "3.6"
+    - os: linux
+      python: "3.7"
 
 before_install:
   # Setup anaconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
     - os: linux
       python: "2.7"
     - os: linux
-      python: "3.4"
-    - os: linux
       python: "3.5"
     - os: linux
       python: "3.6"


### PR DESCRIPTION
It seems that python 3.4 is no longer supported by conda:
https://travis-ci.org/openPMD/openPMD-viewer/jobs/566097165