### PR TITLE
Fix matplotlib custom ticker for matplotlib >= 3.1

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/plotter.py
+++ b/openpmd_viewer/openpmd_timeseries/plotter.py
@@ -46,10 +46,17 @@ if matplotlib_installed:
             # Reduce the threshold for printing an offset on side of the axis
             self._offset_threshold = 2
 
-        def pprint_val( self, x, pos=None ):
+        def __call__(self, x, pos=None):
             """
-            Function that is called for each tick of an axis.
-            Returns the string that
+            Function called for each tick of an axis (for matplotlib>=3.1)
+            Returns the string that appears in the plot.
+            """
+            return self.pprint_val( x, pos )
+
+        def pprint_val( self, x, pos=None):
+            """
+            Function called for each tick of an axis (for matplotlib<3.1)
+            Returns the string that appears in the plot.
             """
             # Calculate the exponent (power of 3)
             xp = (x - self.offset)


### PR DESCRIPTION
The upcoming version 1.0 has a custom ticker for matplotlib axes. 
However, the API for custom ticker changed in matplotlib 3.1.

This PR adapts the custom ticker so that it works for both matplotlib >= 3.1 and matplotlib < 3.1.

I tested this matplotlib 3.1 and checked that I was getting the right formatted ticks.