### PR TITLE
Fix a few bugs with respect to slicing

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/data_reader/field_metainfo.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/field_metainfo.py
@@ -75,16 +75,12 @@ class FieldMetaInformation(object):
             step = grid_spacing[axis] * grid_unitSI
             n_points = shape[axis]
             start = global_offset[axis] * grid_unitSI + position[axis] * step
+            end = start + (n_points - 1) * step
+            axis_points = np.linspace(start, end, n_points, endpoint=True)
             # Create the points below the axis if thetaMode is true
             if axes[axis] == 'r' and thetaMode:
-                end = start + (n_points / 2 - 1) * step
-                axis_points = np.linspace(start, end, n_points / 2,
-                                            endpoint=True)
                 axis_points = np.concatenate((-axis_points[::-1], axis_points))
                 start = -end
-            else:
-                end = start + (n_points - 1) * step
-                axis_points = np.linspace(start, end, n_points, endpoint=True)
             # Register the results in the object
             axis_name = axes[axis]
             setattr(self, axis_name, axis_points)
@@ -142,10 +138,12 @@ class FieldMetaInformation(object):
         delattr(self, obsolete_axis)
         delattr(self, obsolete_axis + 'min')
         delattr(self, obsolete_axis + 'max')
-        # Remove from dictionary
-        for key in list(self.axes.keys()):
-            if self.axes[key] == obsolete_axis:
-                del self.axes[key]
+        # Rebuild the dictionary `axes`, by including the axis
+        # label in the same order, but omitting obsolete_axis
+        ndim = len(self.axes)
+        self.axes = dict( enumerate([
+            self.axes[i] for i in range(ndim) \
+            if self.axes[i] != obsolete_axis ]))
 
         self._generate_imshow_extent()
 

--- a/openpmd_viewer/openpmd_timeseries/data_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/field_reader.py
@@ -227,7 +227,7 @@ def read_field_circ( filename, field_path, slicing, slicing_dir, m=0,
         # Slice field and clear metadata
         inverted_axes_dict = {info.axes[key]: key for key in info.axes.keys()}
         for count, slicing_dir_item in enumerate(slicing_dir):
-            slicing_index = inverted_axes_dict(slicing_dir_item)
+            slicing_index = inverted_axes_dict[slicing_dir_item]
             coord_array = getattr( info, slicing_dir_item )
             # Number of cells along the slicing direction
             n_cells = len(coord_array)

--- a/openpmd_viewer/openpmd_timeseries/main.py
+++ b/openpmd_viewer/openpmd_timeseries/main.py
@@ -344,7 +344,7 @@ class OpenPMDTimeSeries(InteractiveViewer):
         return(data_list)
 
     def get_field(self, field=None, coord=None, t=None, iteration=None,
-                  m='all', theta=0., slicing=0., slicing_dir=None,
+                  m='all', theta=0., slicing=None, slicing_dir=None,
                   plot=False,
                   plot_range=[[None, None], [None, None]], **kw):
         """
@@ -388,6 +388,8 @@ class OpenPMDTimeSeries(InteractiveViewer):
            -1 : lower edge of the simulation box
            0 : middle of the simulation box
            1 : upper edge of the simulation box
+           Default: None, which results in slicing at 0 in all direction
+           of `slicing_dir`.
 
         slicing_dir : str or list of str, optional
            Direction(s) along which to slice the data
@@ -433,6 +435,8 @@ class OpenPMDTimeSeries(InteractiveViewer):
             # Convert to lists
             if not isinstance(slicing_dir, list):
                 slicing_dir = [slicing_dir]
+            if slicing is None:
+                slicing = [0]*len(slicing_dir)
             if not isinstance(slicing, list):
                 slicing = [slicing]
             # Check that the elements are valid

--- a/openpmd_viewer/openpmd_timeseries/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/utilities.py
@@ -193,16 +193,15 @@ def combine_cylindrical_components( Fr, Ft, theta, coord, info ):
         Contains info on the coordinate system
     """
     if theta is not None:
-        # Fr and Fr are 2Darrays
-        assert (Fr.ndim == 2) and (Ft.ndim == 2)
-
         if coord == 'x':
             F = np.cos(theta) * Fr - np.sin(theta) * Ft
         elif coord == 'y':
             F = np.sin(theta) * Fr + np.cos(theta) * Ft
         # Revert the sign below the axis
-        F[: int(F.shape[0] / 2)] *= -1
-
+        if info.axes[0] == 'r':
+            F[ : int(F.shape[0]/2) ] *= -1
+        elif (F.ndim == 2) and (info.axes[1] == 'r'):
+            F[ : , : int(F.shape[1]/2) ] *= -1
     else:
         # Fr, Ft are 3Darrays, info corresponds to Cartesian data
         assert (Fr.ndim == 3) and (Ft.ndim == 3)

--- a/tutorials/2_Specific-field-geometries.ipynb
+++ b/tutorials/2_Specific-field-geometries.ipynb
@@ -130,10 +130,21 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Slice across x and y (i.e. along a line parallel to the z axis)\n",
+    "Ez2, info_Ez2 = ts_3d.get_field( field='E', coord='z', iteration=500,\n",
+    "                                    slicing_dir=['x','y'], plot=True )"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- For one given slicing direction, `slicing` allows to select which slice to take: `slicing` is a number between -1 and 1, where -1 indicates to take the slice at the lower bound of the slicing range (e.g. $z_min$ if `slicing_dir` is `z`) and 1 indicates to take the slice at the upper bound of the slicing range (e.g.  $z_max$ if `slicing_dir` is `z`). For example:"
+    "- For one given slicing direction, `slicing` allows to select which slice to take: `slicing` is a number between -1 and 1, where -1 indicates to take the slice at the lower bound of the slicing range (e.g. $z_min$ if `slicing_dir` is `z`) and 1 indicates to take the slice at the upper bound of the slicing range (e.g.  $z_{max}$ if `slicing_dir` is `z`). For example:"
    ]
   },
   {
@@ -209,7 +220,7 @@
    "source": [
     "The argument `theta` (in radians) selects the plane of observation: this plane contains the $z$ axis and has an angle `theta` with respect to the $x$ axis.\n",
     "\n",
-    "When passing `slicing=None`, `get_field` returns a full 3D Cartesian array. This can be useful for further analysis by hand, with `numpy` (e.g. calculating the total energy in the field), or for comparison with Cartesian simulations."
+    "When passing `theta=None`, `get_field` returns a full 3D Cartesian array. This can be useful for further analysis by hand, with `numpy` (e.g. calculating the total energy in the field), or for comparison with Cartesian simulations."
    ]
   },
   {
@@ -227,7 +238,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- Finally, in cylindrical geometry, the users can also choose the coordinates `r` and `t` for the radial and azimuthal components of the fields. For instance:"
+    "- In cylindrical geometry, the users can also choose the coordinates `r` and `t` for the radial and azimuthal components of the fields. For instance:"
    ]
   },
   {
@@ -238,6 +249,31 @@
    "source": [
     "Er, info_Er = ts_circ.get_field( field='E', coord='r', iteration=500, m=0, \n",
     "                              plot=True, theta=0.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- Finally, in cylindrical geometry, fields can also be sliced, by using the `r` and `z` direction. (Keep in mind that `slicing_dir` is the direction **orthogonal** to the slice.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Er_slice, info = ts_circ.get_field( field='E', coord='r', iteration=500, plot=True, slicing_dir='r' )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Er_slice, info = ts_circ.get_field( field='E', coord='r', iteration=500, plot=True, slicing_dir='z' )"
    ]
   }
  ],
@@ -257,7 +293,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The code for plotting slices of the fields was refactored in version 1.0. However, a number of bugs were introduced:
- The `axes` dictionary (which indicates the axes labels ; e.g. `{0:'x', 1:'y', 2:'z'}`) was not properly updated when using slicing.
- The implementation for `thetaMode` was incorrect for a number of reasons.
- In 3D, version 1.0 introduces the possibility to slice across several axes simultaneously (e.g. `slicing_dir=['x', 'y']`), but the code required the user to explicitly pass `slicing=[0,0]` in this case (otherwise the default `slicing=0` did not match the length of `slicing_dir`). I therefore changed the default of `slicing` to `None`.

I also update one of the notebooks, so that the above features are demonstrated, and automatically tests. (As a reminder, our automated tests run the tutorial notebooks.) 