### PR TITLE
Update laser functions with new slicing syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log / Release Log for openPMD-viewer
 
-## 1.0
+## 1.0.0
 
 This version introduces major changes and breaks backward compatibility.
 
@@ -24,6 +24,10 @@ used to return the central slice along `y` while it now returns the full 3d fiel
 - A new function (`ts.iterate`) was introduced in order to quickly apply a
 given function to all iterations of a time series. See the docstring of
 `ts.iterate` for more information.
+- The function `get_laser_envelope` does not support the argument `index` anymore
+(which was effectively used in order to perform slicing). Instead, users should use
+the argument `slicing_dir`. In addition, `get_laser_envelope` now supports the
+argument `plot_range`.
 
 ## 0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ x, y, z = ts.get_particle(['x', 'y', 'z'], iteration=1000)
 compatibility for 3d field:
 ```get_field(field=field, coord=coord, iteration=iteration)```
 used to return the central slice along `y` while it now returns the full 3d field.
+- `openPMD-viewer` does not rely on Cython anymore. Instead, it uses `numba`
+for functions that perform a substantial amount of computation.
 - A new function (`ts.iterate`) was introduced in order to quickly apply a
 given function to all iterations of a time series. See the docstring of
 `ts.iterate` for more information.
@@ -28,6 +30,7 @@ given function to all iterations of a time series. See the docstring of
 (which was effectively used in order to perform slicing). Instead, users should use
 the argument `slicing_dir`. In addition, `get_laser_envelope` now supports the
 argument `plot_range`.
+- The function `get_laser_waist` does not support the agument `slicing_dir` anymore.
 
 ## 0.9.0
 

--- a/openpmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/openpmd_viewer/addons/pic/lpa_diagnostics.py
@@ -439,7 +439,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         return(current, info)
 
     def get_laser_envelope( self, t=None, iteration=None, pol=None, m='all',
-                            theta=0, slicing=0, slicing_dir=None,
+                            theta=0, slicing=None, slicing_dir=None,
                             plot=False,
                             plot_range=[[None, None], [None, None]], **kw ):
         """
@@ -510,6 +510,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         # Check if polarization has been entered
         if pol not in ['x', 'y']:
             raise ValueError('The `pol` argument is missing or erroneous.')
+
         # Prevent slicing across z at this point
         # (z axis is needed for calculation of envelope)
         slicing_coord_z = None

--- a/openpmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/openpmd_viewer/addons/pic/lpa_diagnostics.py
@@ -942,7 +942,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         elif geometry == "thetaMode":
             slicing_dir = 'r'
         else:
-            raise OpenPMDException('Unknown geometry: %s' %geometry)
+            raise ValueError('Unknown geometry: %s' %geometry)
 
         # Get the field envelope
         env, _ = self.get_laser_envelope(t=t, iteration=iteration,

--- a/openpmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/openpmd_viewer/addons/pic/lpa_diagnostics.py
@@ -15,6 +15,7 @@ import numpy as np
 import scipy.constants as const
 from scipy.optimize import curve_fit
 from openpmd_viewer.openpmd_timeseries.utilities import sanitize_slicing
+from openpmd_viewer.openpmd_timeseries.plotter import check_matplotlib
 from scipy.signal import hilbert
 try:
     import matplotlib.pyplot as plt

--- a/openpmd_viewer/openpmd_timeseries/main.py
+++ b/openpmd_viewer/openpmd_timeseries/main.py
@@ -12,7 +12,8 @@ import numpy as np
 import h5py as h5
 from tqdm import tqdm
 from .utilities import list_h5_files, apply_selection, fit_bins_to_grid, \
-                        combine_cylindrical_components, try_array
+                        combine_cylindrical_components, try_array, \
+                        sanitize_slicing
 from .plotter import Plotter
 from .particle_tracker import ParticleTracker
 from .data_reader.params_reader import read_openPMD_params
@@ -431,14 +432,8 @@ class OpenPMDTimeSeries(InteractiveViewer):
                 "The available fields are: \n - %s\nPlease set the `field` "
                 "argument accordingly." % field_list)
         # Check slicing
+        slicing_dir, slicing = sanitize_slicing(slicing_dir, slicing)
         if slicing_dir is not None:
-            # Convert to lists
-            if not isinstance(slicing_dir, list):
-                slicing_dir = [slicing_dir]
-            if slicing is None:
-                slicing = [0]*len(slicing_dir)
-            if not isinstance(slicing, list):
-                slicing = [slicing]
             # Check that the elements are valid
             axis_labels = self.fields_metadata[field]['axis_labels']
             for axis in slicing_dir:
@@ -447,10 +442,7 @@ class OpenPMDTimeSeries(InteractiveViewer):
                     raise OpenPMDException(
                     'The `slicing_dir` argument is erroneous: contains %s\n'
                     'The available axes are: \n - %s' % (axis, axes_list) )
-            if len(slicing_dir) != len(slicing):
-                raise OpenPMDException(
-                    'The `slicing_dir` argument is erroneous: \nIt should have'
-                    'the same number of elements as `slicing_dir`.')
+
         # Check the coordinate (for vector fields)
         if self.fields_metadata[field]['type'] == 'vector':
             available_coord = ['x', 'y', 'z']

--- a/openpmd_viewer/openpmd_timeseries/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/utilities.py
@@ -32,7 +32,7 @@ def sanitize_slicing(slicing_dir, slicing):
         slicing = [slicing]
     # Check that the length are matching
     if len(slicing_dir) != len(slicing):
-        raise OpenPMDException(
+        raise ValueError(
             'The `slicing_dir` argument is erroneous: \nIt should have'
             'the same number of elements as `slicing_dir`.')
     return slicing_dir, slicing

--- a/openpmd_viewer/openpmd_timeseries/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/utilities.py
@@ -33,9 +33,9 @@ def sanitize_slicing(slicing_dir, slicing):
     # Check that the length are matching
     if len(slicing_dir) != len(slicing):
         raise ValueError(
-            'The `slicing_dir` argument is erroneous: \nIt should have'
+            'The `slicing` argument is erroneous: \nIt should have'
             'the same number of elements as `slicing_dir`.')
-    return slicing_dir, slicing
+    return slicing_dir.copy(), slicing.copy()
 
 
 def list_h5_files(path_to_dir):

--- a/openpmd_viewer/openpmd_timeseries/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/utilities.py
@@ -15,6 +15,29 @@ import h5py
 from .data_reader.particle_reader import read_species_data
 from .numba_wrapper import jit
 
+def sanitize_slicing(slicing_dir, slicing):
+    """
+    TODO
+    """
+    # Skip None and empty lists
+    if slicing_dir is None or slicing_dir == []:
+        return None, None
+
+    # Convert to lists
+    if not isinstance(slicing_dir, list):
+        slicing_dir = [slicing_dir]
+    if slicing is None:
+        slicing = [0]*len(slicing_dir)
+    if not isinstance(slicing, list):
+        slicing = [slicing]
+    # Check that the length are matching
+    if len(slicing_dir) != len(slicing):
+        raise OpenPMDException(
+            'The `slicing_dir` argument is erroneous: \nIt should have'
+            'the same number of elements as `slicing_dir`.')
+    return slicing_dir, slicing
+
+
 def list_h5_files(path_to_dir):
     """
     Return a list of the hdf5 files in this directory,

--- a/openpmd_viewer/openpmd_timeseries/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/utilities.py
@@ -17,7 +17,17 @@ from .numba_wrapper import jit
 
 def sanitize_slicing(slicing_dir, slicing):
     """
-    TODO
+    Return standardized format for `slicing_dir` and `slicing`:
+    - either `slicing_dir` and `slicing` are both `None` (no slicing)
+    - or `slicing_dir` and `slicing` are both lists,
+    with the same number of elements
+
+    Parameters
+    ----------
+    slicing : float, or list of float, or None
+
+    slicing_dir : str, or list of str, or None
+       Direction(s) along which to slice the data
     """
     # Skip None and empty lists
     if slicing_dir is None or slicing_dir == []:
@@ -35,6 +45,12 @@ def sanitize_slicing(slicing_dir, slicing):
         raise ValueError(
             'The `slicing` argument is erroneous: \nIt should have'
             'the same number of elements as `slicing_dir`.')
+
+    # Return a copy. This is because the rest of the `openPMD-viewer` code
+    # sometimes modifies the objects returned by `sanitize_slicing`.
+    # Using a copy avoids directly modifying objects that the user may pass
+    # to this function (and live outside of openPMD-viewer, e.g. directly in
+    # a user's notebook)
     return slicing_dir.copy(), slicing.copy()
 
 

--- a/openpmd_viewer/openpmd_timeseries/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/utilities.py
@@ -9,6 +9,7 @@ License: 3-Clause-BSD-LBNL
 """
 
 import os
+import copy
 import math
 import numpy as np
 import h5py
@@ -51,7 +52,7 @@ def sanitize_slicing(slicing_dir, slicing):
     # Using a copy avoids directly modifying objects that the user may pass
     # to this function (and live outside of openPMD-viewer, e.g. directly in
     # a user's notebook)
-    return slicing_dir.copy(), slicing.copy()
+    return copy.copy(slicing_dir), copy.copy(slicing)
 
 
 def list_h5_files(path_to_dir):


### PR DESCRIPTION
This PR makes a number of laser functions more consistent with the rest of the `openPMD-viewer` API, and refactors some of the code. More specifically:

- The function `get_laser_envelope` does not support the argument `index` anymore
(which was effectively used in order to perform slicing). Instead, users should use
the argument `slicing_dir` (which is now more fully supported).

- In addition, `get_laser_envelope` now supports the argument `plot_range`. This is done by using standard plotting tools that we also use for `get_field`, instead of customize `matplotlib` commands that were used previously.

- A number of laser-diagnostic functions were broken for 3D datasets, because of the new slicing convention in `openPMD-viewer 1.0`, or used complicated syntax in order to extract a 1D lineout. With the ability of `openPMD-viewer 1.0` to do a 1D slice immediately in `get_field` (and in `get_laser_envelope` as part of this PR), this can be fixed/refactored in a more straight-forward way. This PR uses this, and explicitly takes a 1D lineout along the `z` axis, inside the functions `get_spectrum`, `get_a0`, `get_ctau`, `get_spectrogram`.

- The function `get_laser_waist` was also broken for 3D datasets, and it had a `slicing_dir` argument that was not really supported. This was fixed by removing the `slicing_dir` argument and (arbitrarily) slicing across `y` for 3D datasets.

- Finally, a new helper function `sanitize_slicing` is used internally, in order to more easily handle the flexibility of the `slicing` arguments.