### PR TITLE
Travis-CI: -Py3.4 +3.7, +3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,13 @@ matrix:
     - os: linux
       python: "2.7"
     - os: linux
-      python: "3.4"
-    - os: linux
       python: "3.5"
     - os: linux
       python: "3.6"
+    - os: linux
+      python: "3.7"
+    - os: linux
+      python: "3.8"
 
 before_install:
   # Setup anaconda


### PR DESCRIPTION
Drop Python 3.4 support from Travis, add 3.7 and 3.8

Related to #251 