### PR TITLE
Determining whether particles are present: check that there is at least one species

### DIFF
--- a/opmd_viewer/openpmd_timeseries/data_reader/params_reader.py
+++ b/opmd_viewer/openpmd_timeseries/data_reader/params_reader.py
@@ -124,7 +124,9 @@ def read_openPMD_params(filename, extract_parameters=True):
     if ('particlesPath' in f.attrs):        # Check for openPMD 1.1 files
         particle_path = f.attrs['particlesPath'].decode().strip('/')
         if particle_path in bpath.keys():   # Check for openPMD 1.0 files
-            particles_available = True
+            # Check that there is at least one species
+            if len(bpath[particle_path].keys()) > 0:
+                particles_available = True
     if particles_available:
         # Particles are present ; extract the species
         params['avail_species'] = []


### PR DESCRIPTION
In the current `dev` branch, FBPIC determines whether particles are present (and e.g. whether to show a particle panel in `slider`) by checking whether the `particlesPath` is set.

However, the standard does allow the `particlesPath` to be set but to contain no species. (This is the case for instance in the WarpX openPMD output, when no particles are written to the file.)

This PR makes `openPMD-viewer` more robust by explicitly checking that at least one species is present.