### PR TITLE
Template: Location to diags/h5

### DIFF
--- a/openpmd_viewer/notebook_starter/Template_notebook.ipynb
+++ b/openpmd_viewer/notebook_starter/Template_notebook.ipynb
@@ -32,7 +32,7 @@
    "outputs": [],
    "source": [
     "# Replace the string below, to point to your data\n",
-    "ts = OpenPMDTimeSeries('./diags/hdf5/')"
+    "ts = OpenPMDTimeSeries('./diags/h5/')"
    ]
   },
   {


### PR DESCRIPTION
Update the default location of the template notebook.
New naming used in WarpX (PIConGPU uses similarly a directory `simOutput/h5/`).

Other workflows: FBPIC/Warp users rely on this path currently.