### PR TITLE
Rename `slicing_dir` and `slicing` arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ meters
 ```
 x, y, z = ts.get_particle(['x', 'y', 'z'], iteration=1000)
 ```
-- In `ts.get_field`, slicing can now be done in several directions
-(by passing a list as the argument `slicing_dir`), and for
+- In `ts.get_field`, slicing can now be done in several directions, and for
 1d, 2d, 3d, and circ geometries. As a consequence, this breaks backward
 compatibility for 3d field:
 ```get_field(field=field, coord=coord, iteration=iteration)```
 used to return the central slice along `y` while it now returns the full 3d field.
+In addition, the name of the argument of `get_field` that triggers slicing
+has been changed from `slicing_dir` to `slice_across` (and `slicing` has been
+changed to `slice_relative_position`).
 - `openPMD-viewer` does not rely on Cython anymore. Instead, it uses `numba`
 for functions that perform a substantial amount of computation.
 - A new function (`ts.iterate`) was introduced in order to quickly apply a

--- a/openpmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/openpmd_viewer/addons/pic/lpa_diagnostics.py
@@ -475,7 +475,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
            The angle of the plane of observation, with respect to the x axis
 
         slice_across : str or list of str, optional
-           Direction(s) along which to slice the data
+           Direction(s) across which the data should be sliced
            + In cartesian geometry, elements can be:
                - 1d: 'z'
                - 2d: 'x' and/or 'z'

--- a/openpmd_viewer/openpmd_timeseries/data_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/field_reader.py
@@ -15,7 +15,7 @@ from .field_metainfo import FieldMetaInformation
 from ..utilities import construct_3d_from_circ
 
 def read_field_cartesian( filename, field_path, axis_labels,
-                          slicing, slice_across ):
+                          slice_relative_position, slice_across ):
     """
     Extract a given field from an HDF5 file in the openPMD format,
     when the geometry is cartesian (1d, 2d or 3d).
@@ -32,13 +32,6 @@ def read_field_cartesian( filename, field_path, axis_labels,
     axis_labels: list of strings
        The name of the dimensions of the array (e.g. ['x', 'y', 'z'])
 
-    slicing : list of float or None
-       Number(s) between -1 and 1 that indicate where to slice the data,
-       along the directions in `slice_across`
-       -1 : lower edge of the simulation box
-       0 : middle of the simulation box
-       1 : upper edge of the simulation box
-
     slice_across : list of str or None
        Direction(s) along which to slice the data
        Elements can be:
@@ -46,6 +39,13 @@ def read_field_cartesian( filename, field_path, axis_labels,
          - 2d: 'x' and/or 'z'
          - 3d: 'x' and/or 'y' and/or 'z'
        Returned array is reduced by 1 dimension per slicing.
+
+    slice_relative_position : list of float or None
+       Number(s) between -1 and 1 that indicate where to slice the data,
+       along the directions in `slice_across`
+       -1 : lower edge of the simulation box
+       0 : middle of the simulation box
+       1 : upper edge of the simulation box
 
     Returns
     -------
@@ -75,7 +75,7 @@ def read_field_cartesian( filename, field_path, axis_labels,
             # Number of cells along the slicing direction
             n_cells = shape[ slicing_index ]
             # Index of the slice (prevent stepping out of the array)
-            i_cell = int( 0.5 * (slicing[count] + 1.) * n_cells )
+            i_cell = int( 0.5 * (slice_relative_position[count] + 1.) * n_cells )
             i_cell = max( i_cell, 0 )
             i_cell = min( i_cell, n_cells - 1)
             list_i_cell.append(i_cell)
@@ -108,8 +108,8 @@ def read_field_cartesian( filename, field_path, axis_labels,
     return( F, info )
 
 
-def read_field_circ( filename, field_path, slicing, slice_across, m=0,
-                     theta=0. ):
+def read_field_circ( filename, field_path, slice_relative_position,
+                    slice_across, m=0, theta=0. ):
     """
     Extract a given field from an HDF5 file in the openPMD format,
     when the geometry is thetaMode
@@ -132,17 +132,17 @@ def read_field_circ( filename, field_path, slicing, slice_across, m=0,
        corresponding to the plane of observation given by `theta` ;
        otherwise it returns a full 3D Cartesian array
 
-    slicing : list of float or None
+    slice_across : list of str or None
+       Direction(s) along which to slice the data
+       Elements can be 'r' and/or 'z'
+       Returned array is reduced by 1 dimension per slicing.
+
+    slice_relative_position : list of float or None
        Number(s) between -1 and 1 that indicate where to slice the data,
        along the directions in `slice_across`
        -1 : lower edge of the simulation box
        0 : middle of the simulation box
        1 : upper edge of the simulation box
-
-    slice_across : list of str or None
-       Direction(s) along which to slice the data
-       Elements can be 'r' and/or 'z'
-       Returned array is reduced by 1 dimension per slicing.
 
     Returns
     -------
@@ -232,7 +232,7 @@ def read_field_circ( filename, field_path, slicing, slice_across, m=0,
             # Number of cells along the slicing direction
             n_cells = len(coord_array)
             # Index of the slice (prevent stepping out of the array)
-            i_cell = int( 0.5 * (slicing[count] + 1.) * n_cells )
+            i_cell = int( 0.5 * (slice_relative_position[count] + 1.) * n_cells )
             i_cell = max( i_cell, 0 )
             i_cell = min( i_cell, n_cells - 1)
             F_total = np.take( F_total, [i_cell], axis=slicing_index )

--- a/openpmd_viewer/openpmd_timeseries/data_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/field_reader.py
@@ -33,7 +33,7 @@ def read_field_cartesian( filename, field_path, axis_labels,
        The name of the dimensions of the array (e.g. ['x', 'y', 'z'])
 
     slice_across : list of str or None
-       Direction(s) along which to slice the data
+       Direction(s) across which the data should be sliced
        Elements can be:
          - 1d: 'z'
          - 2d: 'x' and/or 'z'
@@ -133,7 +133,7 @@ def read_field_circ( filename, field_path, slice_relative_position,
        otherwise it returns a full 3D Cartesian array
 
     slice_across : list of str or None
-       Direction(s) along which to slice the data
+       Direction(s) across which the data should be sliced
        Elements can be 'r' and/or 'z'
        Returned array is reduced by 1 dimension per slicing.
 

--- a/openpmd_viewer/openpmd_timeseries/data_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/field_reader.py
@@ -15,7 +15,7 @@ from .field_metainfo import FieldMetaInformation
 from ..utilities import construct_3d_from_circ
 
 def read_field_cartesian( filename, field_path, axis_labels,
-                          slicing, slicing_dir ):
+                          slicing, slice_across ):
     """
     Extract a given field from an HDF5 file in the openPMD format,
     when the geometry is cartesian (1d, 2d or 3d).
@@ -34,12 +34,12 @@ def read_field_cartesian( filename, field_path, axis_labels,
 
     slicing : list of float or None
        Number(s) between -1 and 1 that indicate where to slice the data,
-       along the directions in `slicing_dir`
+       along the directions in `slice_across`
        -1 : lower edge of the simulation box
        0 : middle of the simulation box
        1 : upper edge of the simulation box
 
-    slicing_dir : list of str or None
+    slice_across : list of str or None
        Direction(s) along which to slice the data
        Elements can be:
          - 1d: 'z'
@@ -65,12 +65,12 @@ def read_field_cartesian( filename, field_path, axis_labels,
     global_offset = list( group.attrs['gridGlobalOffset'] )
 
     # Slice selection
-    if slicing_dir is not None:
+    if slice_across is not None:
         # Get the integer that correspond to the slicing direction
         list_slicing_index = []
         list_i_cell = []
-        for count, slicing_dir_item in enumerate(slicing_dir):
-            slicing_index = axis_labels.index(slicing_dir_item)
+        for count, slice_across_item in enumerate(slice_across):
+            slicing_index = axis_labels.index(slice_across_item)
             list_slicing_index.append(slicing_index)
             # Number of cells along the slicing direction
             n_cells = shape[ slicing_index ]
@@ -108,7 +108,7 @@ def read_field_cartesian( filename, field_path, axis_labels,
     return( F, info )
 
 
-def read_field_circ( filename, field_path, slicing, slicing_dir, m=0,
+def read_field_circ( filename, field_path, slicing, slice_across, m=0,
                      theta=0. ):
     """
     Extract a given field from an HDF5 file in the openPMD format,
@@ -134,12 +134,12 @@ def read_field_circ( filename, field_path, slicing, slicing_dir, m=0,
 
     slicing : list of float or None
        Number(s) between -1 and 1 that indicate where to slice the data,
-       along the directions in `slicing_dir`
+       along the directions in `slice_across`
        -1 : lower edge of the simulation box
        0 : middle of the simulation box
        1 : upper edge of the simulation box
 
-    slicing_dir : list of str or None
+    slice_across : list of str or None
        Direction(s) along which to slice the data
        Elements can be 'r' and/or 'z'
        Returned array is reduced by 1 dimension per slicing.
@@ -223,12 +223,12 @@ def read_field_circ( filename, field_path, slicing, slicing_dir, m=0,
             F_total[:Nr, :] = (-1) ** m * F[::-1, :]
 
     # Perform slicing if needed
-    if slicing_dir is not None:
+    if slice_across is not None:
         # Slice field and clear metadata
         inverted_axes_dict = {info.axes[key]: key for key in info.axes.keys()}
-        for count, slicing_dir_item in enumerate(slicing_dir):
-            slicing_index = inverted_axes_dict[slicing_dir_item]
-            coord_array = getattr( info, slicing_dir_item )
+        for count, slice_across_item in enumerate(slice_across):
+            slicing_index = inverted_axes_dict[slice_across_item]
+            coord_array = getattr( info, slice_across_item )
             # Number of cells along the slicing direction
             n_cells = len(coord_array)
             # Index of the slice (prevent stepping out of the array)
@@ -238,8 +238,8 @@ def read_field_circ( filename, field_path, slicing, slicing_dir, m=0,
             F_total = np.take( F_total, [i_cell], axis=slicing_index )
         F_total = np.squeeze(F_total)
         # Remove the sliced labels from the FieldMetaInformation
-        for slicing_dir_item in slicing_dir:
-            info._remove_axis(slicing_dir_item)
+        for slice_across_item in slice_across:
+            info._remove_axis(slice_across_item)
 
     # Close the file
     dfile.close()

--- a/openpmd_viewer/openpmd_timeseries/interactive.py
+++ b/openpmd_viewer/openpmd_timeseries/interactive.py
@@ -121,7 +121,8 @@ class InteractiveViewer(object):
                 self.get_field( iteration=self.current_iteration, plot=True,
                     field=fieldtype_button.value, coord=coord_button.value,
                     m=convert_to_int(mode_button.value),
-                    slicing=slicing_button.value, theta=theta_button.value,
+                    slice_relative_position=slicing_button.value,
+                    theta=theta_button.value,
                     slice_across=slice_across,
                     plot_range=plot_range, **kw_fld )
 

--- a/openpmd_viewer/openpmd_timeseries/interactive.py
+++ b/openpmd_viewer/openpmd_timeseries/interactive.py
@@ -112,17 +112,17 @@ class InteractiveViewer(object):
                                 fld_vrange_button.get_range() ]
 
                 # Handle slicing direction
-                if slicing_dir_button.value == 'None':
-                    slicing_dir = None
+                if slice_across_button.value == 'None':
+                    slice_across = None
                 else:
-                    slicing_dir = slicing_dir_button.value
+                    slice_across = slice_across_button.value
 
                 # Call the method get_field
                 self.get_field( iteration=self.current_iteration, plot=True,
                     field=fieldtype_button.value, coord=coord_button.value,
                     m=convert_to_int(mode_button.value),
                     slicing=slicing_button.value, theta=theta_button.value,
-                    slicing_dir=slicing_dir,
+                    slice_across=slice_across,
                     plot_range=plot_range, **kw_fld )
 
         def refresh_ptcl(change=None, force=False):
@@ -218,13 +218,13 @@ class InteractiveViewer(object):
                 theta_button.disabled = True
             # Activate the right slicing options
             if self.fields_metadata[new_field]['geometry'] == '3dcartesian':
-                slicing_dir_button.options = \
+                slice_across_button.options = \
                     self.fields_metadata[new_field]['axis_labels']
-                slicing_dir_button.value = 'y'
+                slice_across_button.value = 'y'
             else:
-                slicing_dir_button.options = ['None'] + \
+                slice_across_button.options = ['None'] + \
                     self.fields_metadata[new_field]['axis_labels']
-                slicing_dir_button.value = 'None'
+                slice_across_button.value = 'None'
 
             # Put back the previous value of the refreshing button
             fld_refresh_toggle.value = saved_refresh_value
@@ -356,12 +356,12 @@ class InteractiveViewer(object):
             # Slicing buttons
             axis_labels = self.fields_metadata[field]['axis_labels']
             if self.fields_metadata[field]['geometry'] == '3dcartesian':
-                slicing_dir_button = create_toggle_buttons( value='y',
+                slice_across_button = create_toggle_buttons( value='y',
                     options=axis_labels )
             else:
-                slicing_dir_button = create_toggle_buttons( value='None',
+                slice_across_button = create_toggle_buttons( value='None',
                     options=['None'] + axis_labels )
-            slicing_dir_button.observe( refresh_field, 'value', 'change' )
+            slice_across_button.observe( refresh_field, 'value', 'change' )
             slicing_button = widgets.FloatSlider( min=-1., max=1., value=0.)
             set_widget_dimensions( slicing_button, width=180 )
             slicing_button.observe( refresh_field, 'value', 'change')
@@ -397,8 +397,8 @@ class InteractiveViewer(object):
             # Slicing container
             slices_widget_list = [
                 add_description("Slice normal:",
-                    slicing_dir_button, width=100),
-                add_description("Slicing:", slicing_button) ]
+                    slice_across_button, width=100),
+                add_description("Slicing position:", slicing_button) ]
             if "thetaMode" in self.avail_geom:
                 # Add widgets specific to azimuthal modes
                 slices_widget_list += [ mode_button,

--- a/openpmd_viewer/openpmd_timeseries/main.py
+++ b/openpmd_viewer/openpmd_timeseries/main.py
@@ -394,7 +394,7 @@ class OpenPMDTimeSeries(InteractiveViewer):
            otherwise it returns a full 3D Cartesian array
 
         slice_across : str or list of str, optional
-           Direction(s) along which to slice the data
+           Direction(s) across which the data should be sliced
            + In cartesian geometry, elements can be:
                - 1d: 'z'
                - 2d: 'x' and/or 'z'

--- a/openpmd_viewer/openpmd_timeseries/main.py
+++ b/openpmd_viewer/openpmd_timeseries/main.py
@@ -355,8 +355,8 @@ class OpenPMDTimeSeries(InteractiveViewer):
         return(data_list)
 
     def get_field(self, field=None, coord=None, t=None, iteration=None,
-                  m='all', theta=0., slicing=None, slice_across=None,
-                  plot=False,
+                  m='all', theta=0., slice_across=None,
+                  slice_relative_position=None, plot=False,
                   plot_range=[[None, None], [None, None]], **kw):
         """
         Extract a given field from an HDF5 file in the openPMD format.
@@ -393,15 +393,6 @@ class OpenPMDTimeSeries(InteractiveViewer):
            corresponding to the plane of observation given by `theta` ;
            otherwise it returns a full 3D Cartesian array
 
-        slicing : float or list of float, optional
-           Number(s) between -1 and 1 that indicate where to slice the data,
-           along the directions in `slice_across`
-           -1 : lower edge of the simulation box
-           0 : middle of the simulation box
-           1 : upper edge of the simulation box
-           Default: None, which results in slicing at 0 in all direction
-           of `slice_across`.
-
         slice_across : str or list of str, optional
            Direction(s) along which to slice the data
            + In cartesian geometry, elements can be:
@@ -411,6 +402,15 @@ class OpenPMDTimeSeries(InteractiveViewer):
            + In cylindrical geometry, elements can be 'r' and/or 'z'
            Returned array is reduced by 1 dimension per slicing.
            If slicing is None, the full grid is returned.
+
+        slice_relative_position : float or list of float, optional
+           Number(s) between -1 and 1 that indicate where to slice the data,
+           along the directions in `slice_across`
+           -1 : lower edge of the simulation box
+           0 : middle of the simulation box
+           1 : upper edge of the simulation box
+           Default: None, which results in slicing at 0 in all direction
+           of `slice_across`.
 
         plot : bool, optional
            Whether to plot the requested quantity
@@ -442,7 +442,8 @@ class OpenPMDTimeSeries(InteractiveViewer):
                 "The available fields are: \n - %s\nPlease set the `field` "
                 "argument accordingly." % field_list)
         # Check slicing
-        slice_across, slicing = sanitize_slicing(slice_across, slicing)
+        slice_across, slice_relative_position = \
+            sanitize_slicing(slice_across, slice_relative_position)
         if slice_across is not None:
             # Check that the elements are valid
             axis_labels = self.fields_metadata[field]['axis_labels']
@@ -493,22 +494,22 @@ class OpenPMDTimeSeries(InteractiveViewer):
         axis_labels = self.fields_metadata[field]['axis_labels']
         # - For cartesian
         if geometry in ["1dcartesian", "2dcartesian", "3dcartesian"]:
-            F, info = read_field_cartesian(
-                filename, field_path, axis_labels, slicing, slice_across)
+            F, info = read_field_cartesian( filename, field_path,
+                axis_labels, slice_relative_position, slice_across)
         # - For thetaMode
         elif geometry == "thetaMode":
             if (coord in ['x', 'y']) and \
                     (self.fields_metadata[field]['type'] == 'vector'):
                 # For Cartesian components, combine r and t components
-                Fr, info = read_field_circ(filename, field + '/r', slicing,
-                                           slice_across, m, theta)
-                Ft, info = read_field_circ(filename, field + '/t', slicing,
-                                           slice_across, m, theta)
+                Fr, info = read_field_circ(filename, field + '/r',
+                    slice_relative_position, slice_across, m, theta)
+                Ft, info = read_field_circ(filename, field + '/t',
+                    slice_relative_position, slice_across, m, theta)
                 F = combine_cylindrical_components(Fr, Ft, theta, coord, info)
             else:
                 # For cylindrical or scalar components, no special treatment
-                F, info = read_field_circ(filename, field_path, slicing,
-                                          slice_across, m, theta)
+                F, info = read_field_circ(filename, field_path,
+                    slice_relative_position, slice_across, m, theta)
 
         # Plot the resulting field
         # Deactivate plotting when there is no slice selection
@@ -522,7 +523,7 @@ class OpenPMDTimeSeries(InteractiveViewer):
                     plot_range=plot_range, **kw)
             else:
                 raise OpenPMDException('Cannot plot %d-dimensional data.\n'
-                    'Use slicing, or set `plot=False`' % F.ndim)
+                    'Use the argument `slice_across`, or set `plot=False`' % F.ndim)
 
         # Return the result
         return(F, info)

--- a/openpmd_viewer/openpmd_timeseries/plotter.py
+++ b/openpmd_viewer/openpmd_timeseries/plotter.py
@@ -318,7 +318,7 @@ class Plotter(object):
         ax.get_xaxis().set_major_formatter( tick_formatter )
         ax.get_yaxis().set_major_formatter( tick_formatter )
 
-    def show_field_2d(self, F, info, slicing_dir, m, field_label, geometry,
+    def show_field_2d(self, F, info, slice_across, m, field_label, geometry,
                         current_i, plot_range, **kw):
         """
         Plot the given field in 2D
@@ -331,9 +331,9 @@ class Plotter(object):
         info: a FieldMetaInformation object
             Contains the information about the plotted field
 
-        slicing_dir : str, optional
+        slice_across : str, optional
            Only used for 3dcartesian geometry
-           The direction along which the data is sliced
+           The direction across which the data is sliced
 
         m: int
            Only used for thetaMode geometry

--- a/openpmd_viewer/openpmd_timeseries/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/utilities.py
@@ -16,43 +16,43 @@ import h5py
 from .data_reader.particle_reader import read_species_data
 from .numba_wrapper import jit
 
-def sanitize_slicing(slicing_dir, slicing):
+def sanitize_slicing(slice_across, slicing):
     """
-    Return standardized format for `slicing_dir` and `slicing`:
-    - either `slicing_dir` and `slicing` are both `None` (no slicing)
-    - or `slicing_dir` and `slicing` are both lists,
+    Return standardized format for `slice_across` and `slicing`:
+    - either `slice_across` and `slicing` are both `None` (no slicing)
+    - or `slice_across` and `slicing` are both lists,
     with the same number of elements
 
     Parameters
     ----------
     slicing : float, or list of float, or None
 
-    slicing_dir : str, or list of str, or None
+    slice_across : str, or list of str, or None
        Direction(s) along which to slice the data
     """
     # Skip None and empty lists
-    if slicing_dir is None or slicing_dir == []:
+    if slice_across is None or slice_across == []:
         return None, None
 
     # Convert to lists
-    if not isinstance(slicing_dir, list):
-        slicing_dir = [slicing_dir]
+    if not isinstance(slice_across, list):
+        slice_across = [slice_across]
     if slicing is None:
-        slicing = [0]*len(slicing_dir)
+        slicing = [0]*len(slice_across)
     if not isinstance(slicing, list):
         slicing = [slicing]
     # Check that the length are matching
-    if len(slicing_dir) != len(slicing):
+    if len(slice_across) != len(slicing):
         raise ValueError(
             'The `slicing` argument is erroneous: \nIt should have'
-            'the same number of elements as `slicing_dir`.')
+            'the same number of elements as `slice_across`.')
 
     # Return a copy. This is because the rest of the `openPMD-viewer` code
     # sometimes modifies the objects returned by `sanitize_slicing`.
     # Using a copy avoids directly modifying objects that the user may pass
     # to this function (and live outside of openPMD-viewer, e.g. directly in
     # a user's notebook)
-    return copy.copy(slicing_dir), copy.copy(slicing)
+    return copy.copy(slice_across), copy.copy(slicing)
 
 
 def list_h5_files(path_to_dir):

--- a/openpmd_viewer/openpmd_timeseries/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/utilities.py
@@ -16,16 +16,16 @@ import h5py
 from .data_reader.particle_reader import read_species_data
 from .numba_wrapper import jit
 
-def sanitize_slicing(slice_across, slicing):
+def sanitize_slicing(slice_across, slice_relative_position):
     """
-    Return standardized format for `slice_across` and `slicing`:
-    - either `slice_across` and `slicing` are both `None` (no slicing)
-    - or `slice_across` and `slicing` are both lists,
+    Return standardized format for `slice_across` and `slice_relative_position`:
+    - either `slice_across` and `slice_relative_position` are both `None` (no slicing)
+    - or `slice_across` and `slice_relative_position` are both lists,
     with the same number of elements
 
     Parameters
     ----------
-    slicing : float, or list of float, or None
+    slice_relative_position : float, or list of float, or None
 
     slice_across : str, or list of str, or None
        Direction(s) along which to slice the data
@@ -37,14 +37,14 @@ def sanitize_slicing(slice_across, slicing):
     # Convert to lists
     if not isinstance(slice_across, list):
         slice_across = [slice_across]
-    if slicing is None:
-        slicing = [0]*len(slice_across)
-    if not isinstance(slicing, list):
-        slicing = [slicing]
+    if slice_relative_position is None:
+        slice_relative_position = [0]*len(slice_across)
+    if not isinstance(slice_relative_position, list):
+        slice_relative_position = [slice_relative_position]
     # Check that the length are matching
-    if len(slice_across) != len(slicing):
+    if len(slice_across) != len(slice_relative_position):
         raise ValueError(
-            'The `slicing` argument is erroneous: \nIt should have'
+            'The argument `slice_relative_position` is erroneous: \nIt should have'
             'the same number of elements as `slice_across`.')
 
     # Return a copy. This is because the rest of the `openPMD-viewer` code
@@ -52,7 +52,7 @@ def sanitize_slicing(slice_across, slicing):
     # Using a copy avoids directly modifying objects that the user may pass
     # to this function (and live outside of openPMD-viewer, e.g. directly in
     # a user's notebook)
-    return copy.copy(slice_across), copy.copy(slicing)
+    return copy.copy(slice_across), copy.copy(slice_relative_position)
 
 
 def list_h5_files(path_to_dir):

--- a/openpmd_viewer/openpmd_timeseries/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/utilities.py
@@ -28,7 +28,7 @@ def sanitize_slicing(slice_across, slice_relative_position):
     slice_relative_position : float, or list of float, or None
 
     slice_across : str, or list of str, or None
-       Direction(s) along which to slice the data
+       Direction(s) across which the data should be sliced
     """
     # Skip None and empty lists
     if slice_across is None or slice_across == []:

--- a/opmd_viewer/__init__.py
+++ b/opmd_viewer/__init__.py
@@ -20,7 +20,8 @@ from openpmd_viewer import OpenPMDTimeSeries
 Please have a look at the list of the changes introduced in version 1.X here:
 https://github.com/openPMD/openPMD-viewer/blob/upcoming-1.0/CHANGELOG.md#10
 In particular, note that `get_particle` now returns particle positions in
-meters (not in microns anymore).
+meters (not in microns anymore) and that the syntax for slicing fields has
+changed.
 
 * If you wish to go back to the old openPMD-viewer version 0.X, use:
 ```

--- a/tutorials/2_Specific-field-geometries.ipynb
+++ b/tutorials/2_Specific-field-geometries.ipynb
@@ -104,7 +104,7 @@
     "## 3D Cartesian geometry\n",
     "\n",
     "For 3D Cartesian geometry, the `get_field` method has additional arguments, in order to select a 2D slice into the 3D volume:\n",
-    "- `slicing_dir` allows to choose the axis across which the slice is taken. See the examples below:"
+    "- `slice_across` allows to choose the axis across which the slice is taken. See the examples below:"
    ]
   },
   {
@@ -115,7 +115,7 @@
    "source": [
     "# Slice across y (i.e. in a plane parallel to x-z)\n",
     "Ez1, info_Ez1 = ts_3d.get_field( field='E', coord='z', iteration=500, \n",
-    "                                    slicing_dir='y', plot=True )"
+    "                                    slice_across='y', plot=True )"
    ]
   },
   {
@@ -126,7 +126,7 @@
    "source": [
     "# Slice across z (i.e. in a plane parallel to x-y)\n",
     "Ez2, info_Ez2 = ts_3d.get_field( field='E', coord='z', iteration=500,\n",
-    "                                    slicing_dir='z', plot=True )"
+    "                                    slice_across='z', plot=True )"
    ]
   },
   {
@@ -137,14 +137,14 @@
    "source": [
     "# Slice across x and y (i.e. along a line parallel to the z axis)\n",
     "Ez2, info_Ez2 = ts_3d.get_field( field='E', coord='z', iteration=500,\n",
-    "                                    slicing_dir=['x','y'], plot=True )"
+    "                                    slice_across=['x','y'], plot=True )"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- For one given slicing direction, `slicing` allows to select which slice to take: `slicing` is a number between -1 and 1, where -1 indicates to take the slice at the lower bound of the slicing range (e.g. $z_min$ if `slicing_dir` is `z`) and 1 indicates to take the slice at the upper bound of the slicing range (e.g.  $z_{max}$ if `slicing_dir` is `z`). For example:"
+    "- For one given slicing direction, `slicing` allows to select which slice to take: `slicing` is a number between -1 and 1, where -1 indicates to take the slice at the lower bound of the slicing range (e.g. $z_min$ if `slice_across` is `z`) and 1 indicates to take the slice at the upper bound of the slicing range (e.g.  $z_{max}$ if `slice_across` is `z`). For example:"
    ]
   },
   {
@@ -155,7 +155,7 @@
    "source": [
     "# Slice across z, very close to zmin.\n",
     "Ez2, info_Ez2 = ts_3d.get_field( field='E', coord='z', iteration=500, \n",
-    "                                slicing_dir='z', slicing=-0.9, plot=True )"
+    "                                slice_across='z', slicing=-0.9, plot=True )"
    ]
   },
   {
@@ -255,7 +255,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- Finally, in cylindrical geometry, fields can also be sliced, by using the `r` and `z` direction. (Keep in mind that `slicing_dir` is the direction **orthogonal** to the slice.)"
+    "- Finally, in cylindrical geometry, fields can also be sliced, by using the `r` and `z` direction. (Keep in mind that `slice_across` is the direction **orthogonal** to the slice.)"
    ]
   },
   {
@@ -264,7 +264,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Er_slice, info = ts_circ.get_field( field='E', coord='r', iteration=500, plot=True, slicing_dir='r' )"
+    "Er_slice, info = ts_circ.get_field( field='E', coord='r', iteration=500, plot=True, slice_across='r' )"
    ]
   },
   {
@@ -273,7 +273,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Er_slice, info = ts_circ.get_field( field='E', coord='r', iteration=500, plot=True, slicing_dir='z' )"
+    "Er_slice, info = ts_circ.get_field( field='E', coord='r', iteration=500, plot=True, slice_across='z' )"
    ]
   }
  ],

--- a/tutorials/2_Specific-field-geometries.ipynb
+++ b/tutorials/2_Specific-field-geometries.ipynb
@@ -144,7 +144,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- For one given slicing direction, `slicing` allows to select which slice to take: `slicing` is a number between -1 and 1, where -1 indicates to take the slice at the lower bound of the slicing range (e.g. $z_min$ if `slice_across` is `z`) and 1 indicates to take the slice at the upper bound of the slicing range (e.g.  $z_{max}$ if `slice_across` is `z`). For example:"
+    "- For one given slicing direction, `slice_relative_position` allows to select which slice to take: `slice_relative_position` is a number between -1 and 1, where -1 indicates to take the slice at the lower bound of the slicing range (e.g. $z_{min}$ if `slice_across` is `z`) and 1 indicates to take the slice at the upper bound of the slicing range (e.g.  $z_{max}$ if `slice_across` is `z`). For example:"
    ]
   },
   {
@@ -155,14 +155,14 @@
    "source": [
     "# Slice across z, very close to zmin.\n",
     "Ez2, info_Ez2 = ts_3d.get_field( field='E', coord='z', iteration=500, \n",
-    "                                slice_across='z', slicing=-0.9, plot=True )"
+    "     slice_across='z', slice_relative_position=-0.9, plot=True )"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When passing `slicing=None`, `get_field` returns a full 3D Cartesian array. This can be useful for further analysis by hand, with `numpy` (e.g. calculating the total energy in the field)."
+    "When passing `slice_across=None`, `get_field` returns a full 3D Cartesian array. This can be useful for further analysis by hand, with `numpy` (e.g. calculating the total energy in the field)."
    ]
   },
   {
@@ -172,7 +172,7 @@
    "outputs": [],
    "source": [
     "# Get the full 3D Cartesian array\n",
-    "Ez_3d, info_Ez_3d = ts_3d.get_field( field='E', coord='z', iteration=500, slicing=None )\n",
+    "Ez_3d, info_Ez_3d = ts_3d.get_field( field='E', coord='z', iteration=500, slice_across=None )\n",
     "print( Ez_3d.ndim )"
    ]
   },


### PR DESCRIPTION
This PR is a proposal to change the name of the slicing arguments in openPMD-viewer 1.0. 

More specifically:
- `slicing_dir` is replaced by `slice_across`
- `slicing` is replaced by `slice_relative_position`

Here are the motivations for this change:

- `slicing_dir` is not a very descriptive name. It is unclear whether the slice is along or across the specified direction. Switching this to `slice_across` also makes it easy to later add another (complementary) optional argument `slice_along`.

- `slicing` is even less descriptive. `slice_relative_position` makes this much clearer. It also makse it easy to later add another optional argument `slice_absolute_position`.

- Because `slicing` is shorter than `slicing_dir`, users (myself included) often remember this argument and try to do e.g. `get_field( slicing='x')`, which fails. The relative position of the slice in fact rarely needs to be changed, and so it is natural for it to have a longer name (`slice_absolute_position` instead of `slicing`).