### PR TITLE
Fix plotting code for python 2

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/plotter.py
+++ b/openpmd_viewer/openpmd_timeseries/plotter.py
@@ -60,7 +60,7 @@ if matplotlib_installed:
             # Calculate the exponent (power of 3)
             xp = (x - self.offset)
             if xp != 0:
-                exponent = 3 * math.floor( math.log10(abs(xp)) / 3 )
+                exponent = int(3 * math.floor( math.log10(abs(xp)) / 3 ))
             else:
                 exponent = 0
             # Show 3 digits at most after decimal point


### PR DESCRIPTION
`math.floor` returns an `int` in Python 3, but a `float` in Python 2. This caused the openPMD-viewer 1.0.0 plotter to fail in Python 2. This PR fixes it.