### PR TITLE
Bump notebook format minor version to 2

### DIFF
--- a/openpmd_viewer/notebook_starter/Template_notebook.ipynb
+++ b/openpmd_viewer/notebook_starter/Template_notebook.ipynb
@@ -68,5 +68,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 2
 }

--- a/tutorials/1_Introduction-to-the-API.ipynb
+++ b/tutorials/1_Introduction-to-the-API.ipynb
@@ -369,5 +369,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/tutorials/2_Specific-field-geometries.ipynb
+++ b/tutorials/2_Specific-field-geometries.ipynb
@@ -297,5 +297,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/tutorials/3_Introduction-to-the-GUI.ipynb
+++ b/tutorials/3_Introduction-to-the-GUI.ipynb
@@ -203,5 +203,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/tutorials/4_Particle_selection.ipynb
+++ b/tutorials/4_Particle_selection.ipynb
@@ -460,5 +460,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/tutorials/5_Laser-plasma_tools.ipynb
+++ b/tutorials/5_Laser-plasma_tools.ipynb
@@ -444,5 +444,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
Recently, I noticed that, whenever the `slider` is used in a notebook, I get the following warning when the notebook is saved (either when I save it by hand or when it is auto-saved):
![Screenshot from 2020-03-11 09-32-35](https://user-images.githubusercontent.com/6685781/76444610-6c78ab80-6381-11ea-9ec4-cbb3e74b3030.png)

As mentioned in [this issue](https://github.com/jupyter-widgets/ipywidgets/issues/1003), this seems to be because of a bug associated with notebook format 4.1. Therefore, I bumped the version of all notebooks to 4.2. This fixes the original issue.