### PR TITLE
Implement `openpmd-api` backend as an alternative to `h5py`

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/data_reader/data_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/data_reader.py
@@ -64,7 +64,12 @@ class DataReader( object ):
                 h5py_reader.list_files( path_to_dir )
             # Store dictionary of correspondence between iteration and file
             self.iteration_to_file = iteration_to_file
-
+            if len(iterations) == 0:
+                raise RuntimeError(
+                    "Found no valid files in directory {0}.\n"
+                    "Please check that this is the path to the openPMD files."
+                    "(valid files must have the extension '.h5')"
+                    .format(path_to_dir))
         elif backend == 'openpmd-api':
             # guess file ending from first file in directory
             first_file_name = None
@@ -72,9 +77,11 @@ class DataReader( object ):
                 if file_name.split(os.extsep)[-1] in io.file_extensions:
                     first_file_name = file_name
             if first_file_name is None:
-                raise RuntimeError('Unknown files in {0}. '
-                                   'Not found in supported extensions: {1}'
-                                   .format(path_to_dir, io.file_extensions))
+                raise RuntimeError(
+                    "Found no valid files in directory {0}.\n"
+                    "Please check that this is the path to the openPMD files."
+                    "(valid files must have one of the following extensions: {1})"
+                    .format(path_to_dir, io.file_extensions))
 
             # match last occurance of integers and replace with %T wildcards
             # examples: data00000100.h5 diag4_00000500.h5 io12.0.bp

--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/__init__.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/__init__.py
@@ -1,0 +1,7 @@
+from .particle_reader import read_species_data
+from .params_reader import read_openPMD_params
+from .field_reader import read_field_cartesian, \
+    read_field_circ, get_grid_parameters
+
+__all__ = ['read_species_data', 'read_openPMD_params', 'read_field_cartesian',
+           'read_field_circ', 'get_grid_parameters']

--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/field_reader.py
@@ -1,0 +1,339 @@
+"""
+This file is part of the openPMD-viewer.
+
+It defines functions that can read the fields from an HDF5 file.
+
+Copyright 2020, openPMD-viewer contributors
+Author: Axel Huebl
+License: 3-Clause-BSD-LBNL
+"""
+
+import numpy as np
+from .utilities import get_data
+from openpmd_viewer.openpmd_timeseries.field_metainfo import FieldMetaInformation
+from openpmd_viewer.openpmd_timeseries.utilities import construct_3d_from_circ
+
+
+def read_field_cartesian( series, iteration, field_name, component_name,
+                          axis_labels, slice_relative_position, slice_across ):
+    """
+    Extract a given field from an HDF5 file in the openPMD format,
+    when the geometry is cartesian (1d, 2d or 3d).
+
+    Parameters
+    ----------
+    series: openpmd_api.Series
+        An open, readable openPMD-api series object
+
+    iteration: integer
+        Iteration from which parameters should be extracted
+
+    field_name : string, optional
+       Which field to extract
+
+    component_name : string, optional
+       Which component of the field to extract
+
+    axis_labels: list of strings
+       The name of the dimensions of the array (e.g. ['x', 'y', 'z'])
+
+    slice_across : list of str or None
+       Direction(s) across which the data should be sliced
+       Elements can be:
+         - 1d: 'z'
+         - 2d: 'x' and/or 'z'
+         - 3d: 'x' and/or 'y' and/or 'z'
+       Returned array is reduced by 1 dimension per slicing.
+
+    slice_relative_position : list of float or None
+       Number(s) between -1 and 1 that indicate where to slice the data,
+       along the directions in `slice_across`
+       -1 : lower edge of the simulation box
+       0 : middle of the simulation box
+       1 : upper edge of the simulation box
+
+    Returns
+    -------
+    A tuple with
+       F : a ndarray containing the required field
+       info : a FieldMetaInformation object
+       (contains information about the grid; see the corresponding docstring)
+    """
+    it = series.iterations[iteration]
+
+    # Extract the dataset and and corresponding group
+    field = it.meshes[field_name]
+    if field.scalar:
+        component = next(field.items())[1]
+    else:
+        component = field[component_name]
+
+    # Dimensions of the grid
+    shape = component.shape
+    # FIXME here and in h5py reader, we need to invert the order on 'F'
+    grid_spacing = field.grid_spacing
+    global_offset = field.grid_global_offset
+    grid_unit_SI = field.grid_unit_SI
+    grid_position = component.position
+
+    # Slice selection
+    #   TODO put in general utilities
+    if slice_across is not None:
+        # Get the integer that correspond to the slicing direction
+        list_slicing_index = []
+        list_i_cell = []
+        for count, slice_across_item in enumerate(slice_across):
+            slicing_index = axis_labels.index(slice_across_item)
+            list_slicing_index.append(slicing_index)
+            # Number of cells along the slicing direction
+            n_cells = shape[ slicing_index ]
+            # Index of the slice (prevent stepping out of the array)
+            i_cell = int( 0.5 * (slice_relative_position[count] + 1.) * n_cells )
+            i_cell = max( i_cell, 0 )
+            i_cell = min( i_cell, n_cells - 1)
+            list_i_cell.append(i_cell)
+
+        # Remove metainformation relative to the slicing index
+        # Successive pops starting from last coordinate to slice
+        shape = [ x for index, x in enumerate(shape)
+                  if index not in list_slicing_index ]
+        grid_spacing = [ x for index, x in enumerate(grid_spacing)
+                         if index not in list_slicing_index ]
+        global_offset = [ x for index, x in enumerate(global_offset)
+                          if index not in list_slicing_index ]
+        axis_labels = [ x for index, x in enumerate(axis_labels)
+                         if index not in list_slicing_index ]
+
+        axes = { i: axis_labels[i] for i in range(len(axis_labels)) }
+        # Extract data
+        F = get_data( series, component, list_i_cell, list_slicing_index )
+        info = FieldMetaInformation( axes, shape, grid_spacing, global_offset,
+                grid_unit_SI, grid_position )
+    else:
+        F = get_data( series, component )
+        axes = { i: axis_labels[i] for i in range(len(axis_labels)) }
+        info = FieldMetaInformation( axes, F.shape,
+            grid_spacing, global_offset,
+            grid_unit_SI, grid_position )
+
+    return F, info 
+
+
+def read_field_circ( series, iteration, field_name, component_name,
+                     slice_relative_position, slice_across, m=0, theta=0. ):
+    """
+    Extract a given field from an HDF5 file in the openPMD format,
+    when the geometry is thetaMode
+
+    Parameters
+    ----------
+    series: openpmd_api.Series
+        An open, readable openPMD-api series object
+
+    iteration: integer
+        Iteration from which parameters should be extracted
+
+    field_name : string, optional
+       Which field to extract
+
+    component_name : string, optional
+       Which component of the field to extract
+
+    m : int or string, optional
+       The azimuthal mode to be extracted
+
+    theta : float or None
+       Angle of the plane of observation with respect to the x axis
+       If `theta` is not None, then this function returns a 2D array
+       corresponding to the plane of observation given by `theta` ;
+       otherwise it returns a full 3D Cartesian array
+
+    slice_across : list of str or None
+       Direction(s) across which the data should be sliced
+       Elements can be 'r' and/or 'z'
+       Returned array is reduced by 1 dimension per slicing.
+
+    slice_relative_position : list of float or None
+       Number(s) between -1 and 1 that indicate where to slice the data,
+       along the directions in `slice_across`
+       -1 : lower edge of the simulation box
+       0 : middle of the simulation box
+       1 : upper edge of the simulation box
+
+    Returns
+    -------
+    A tuple with
+       F : a 3darray or 2darray containing the required field,
+           depending on whether `theta` is None or not
+       info : a FieldMetaInformation object
+       (contains information about the grid; see the corresponding docstring)
+    """
+    it = series.iterations[iteration]
+
+    # Extract the dataset and and corresponding group
+    field = it.meshes[field_name]
+    if field.scalar:
+        component = next(field.items())[1]
+    else:
+        component = field[component_name]
+
+    # Extract the metainformation
+    #   FIXME here and in h5py reader, we need to invert the order on 'F' for
+    #         grid spacing/offset/position
+    Nm, Nr, Nz = component.shape
+    info = FieldMetaInformation( { 0: 'r', 1: 'z' }, (Nr, Nz),
+        field.grid_spacing, field.grid_global_offset,
+        field.grid_unit_SI, component.position, thetaMode=True )
+
+    # Convert to a 3D Cartesian array if theta is None
+    if theta is None:
+
+        # Get cylindrical info
+        rmax = info.rmax
+        inv_dr = 1./info.dr
+        Fcirc = get_data( series, component )  # (Extracts all modes)
+        nr = Fcirc.shape[1]
+        if m == 'all':
+            modes = [ mode for mode in range(0, int(Nm / 2) + 1) ]
+        else:
+            modes = [ m ]
+        modes = np.array( modes, dtype='int' )
+        nmodes = len(modes)
+
+        # Convert cylindrical data to Cartesian data
+        info._convert_cylindrical_to_3Dcartesian()
+        nx, ny, nz = len(info.x), len(info.y), len(info.z)
+        F_total = np.zeros( (nx, ny, nz) )
+        construct_3d_from_circ( F_total, Fcirc, info.x, info.y, modes,
+            nx, ny, nz, nr, nmodes, inv_dr, rmax )
+
+    else:
+
+        # Extract the modes and recombine them properly
+        F_total = np.zeros( (2 * Nr, Nz ) )
+        if m == 'all':
+            # Sum of all the modes
+            # - Prepare the multiplier arrays
+            mult_above_axis = [1]
+            mult_below_axis = [1]
+            for mode in range(1, int(Nm / 2) + 1):
+                cos = np.cos( mode * theta )
+                sin = np.sin( mode * theta )
+                mult_above_axis += [cos, sin]
+                mult_below_axis += [ (-1) ** mode * cos, (-1) ** mode * sin ]
+            mult_above_axis = np.array( mult_above_axis )
+            mult_below_axis = np.array( mult_below_axis )
+            # - Sum the modes
+            F = get_data( series, component )  # (Extracts all modes)
+            F_total[Nr:, :] = np.tensordot( mult_above_axis,
+                                            F, axes=(0, 0) )[:, :]
+            F_total[:Nr, :] = np.tensordot( mult_below_axis,
+                                            F, axes=(0, 0) )[::-1, :]
+        elif m == 0:
+            # Extract mode 0
+            F = get_data( series, component, 0, 0 )
+            F_total[Nr:, :] = F[:, :]
+            F_total[:Nr, :] = F[::-1, :]
+        else:
+            # Extract higher mode
+            cos = np.cos( m * theta )
+            sin = np.sin( m * theta )
+            F_cos = get_data( series, component, 2 * m - 1, 0 )
+            F_sin = get_data( series, component, 2 * m, 0 )
+            F = cos * F_cos + sin * F_sin
+            F_total[Nr:, :] = F[:, :]
+            F_total[:Nr, :] = (-1) ** m * F[::-1, :]
+
+    # Perform slicing if needed
+    if slice_across is not None:
+        # Slice field and clear metadata
+        inverted_axes_dict = {info.axes[key]: key for key in info.axes.keys()}
+        for count, slice_across_item in enumerate(slice_across):
+            slicing_index = inverted_axes_dict[slice_across_item]
+            coord_array = getattr( info, slice_across_item )
+            # Number of cells along the slicing direction
+            n_cells = len(coord_array)
+            # Index of the slice (prevent stepping out of the array)
+            i_cell = int( 0.5 * (slice_relative_position[count] + 1.) * n_cells )
+            i_cell = max( i_cell, 0 )
+            i_cell = min( i_cell, n_cells - 1)
+            F_total = np.take( F_total, [i_cell], axis=slicing_index )
+        F_total = np.squeeze(F_total)
+        # Remove the sliced labels from the FieldMetaInformation
+        for slice_across_item in slice_across:
+            info._remove_axis(slice_across_item)
+
+    return F_total, info
+
+
+# FIXME this looks like it can be generalized from already read meta-data
+def get_grid_parameters( series, iteration, avail_fields, metadata ):
+    """
+    Return the parameters of the spatial grid (grid size and grid range)
+    in two dictionaries
+
+    Parameters:
+    -----------
+    series: openpmd_api.Series
+        An open, readable openPMD-api series object
+
+    iteration: integer
+        Iteration from which parameters should be extracted
+
+    avail_fields: list
+       A list of the available fields
+       e.g. ['B', 'E', 'rho']
+
+    metadata: dictionary
+      A dictionary whose keys are the fields of `avail_fields` and
+      whose values are dictionaries that contain metadata (e.g. geometry)
+
+    Returns:
+    --------
+    A tuple with `grid_size_dict` and `grid_range_dict`
+    Both objects are dictionaries, with their keys being the labels of the axis
+    of the grid (e.g. 'x', 'y', 'z')
+    The values of `grid_size_dict` are the number of gridpoints along each axis
+    The values of `grid_range_dict` are lists of two floats, which correspond
+    to the min and max of the grid, along each axis.
+    """
+    it = series.iterations[iteration]
+
+    # Pick field with the highest dimensionality ('3d'>'thetaMode'>'2d')
+    # (This function is for the purpose of histogramming the particles;
+    # in this case, the highest dimensionality ensures that more particle
+    # quantities can be properly histogrammed.)
+    geometry_ranking = {'1dcartesian': 0, '2dcartesian': 1,
+                        'thetaMode': 2, '3dcartesian': 3}
+    fields_ranking = [ geometry_ranking[ metadata[field]['geometry'] ]
+                        for field in avail_fields ]
+    index_best_field = fields_ranking.index( max(fields_ranking) )
+    field_name = avail_fields[ index_best_field ]
+
+    # Extract the dataset and and corresponding group
+    # For field vector, extract the first component, to get the dataset
+    field = it.meshes[field_name]
+    component = next(field.items())[1]
+
+    # Extract relevant quantities
+    #   FIXME here and in h5py reader, we need to invert the order on 'F' for
+    #         grid spacing/offset/position
+    labels = field.axis_labels
+    grid_spacing = np.array(field.grid_spacing) * field.grid_unit_SI
+    grid_offset = np.array(field.grid_global_offset) * field.grid_unit_SI
+    grid_size = component.shape
+    if metadata[field_name]['geometry'] == 'thetaMode':
+        # In thetaMode: skip the first number of dset.shape, as this
+        # corresponds to the number of modes
+        grid_size = component.shape[1:]
+
+    # Build the dictionaries grid_size_dict and grid_range_dict
+    grid_size_dict = {}
+    grid_range_dict = {}
+    for i in range(len(labels)):
+        coord = labels[i]
+        grid_size_dict[coord] = grid_size[i]
+        grid_range_dict[coord] = \
+            [ grid_offset[i], grid_offset[i] + grid_size[i] * grid_spacing[i] ]
+
+    return grid_size_dict, grid_range_dict

--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/field_reader.py
@@ -17,7 +17,7 @@ from openpmd_viewer.openpmd_timeseries.utilities import construct_3d_from_circ
 def read_field_cartesian( series, iteration, field_name, component_name,
                           axis_labels, slice_relative_position, slice_across ):
     """
-    Extract a given field from an HDF5 file in the openPMD format,
+    Extract a given field from a file in the openPMD format,
     when the geometry is cartesian (1d, 2d or 3d).
 
     Parameters
@@ -122,7 +122,7 @@ def read_field_cartesian( series, iteration, field_name, component_name,
 def read_field_circ( series, iteration, field_name, component_name,
                      slice_relative_position, slice_across, m=0, theta=0. ):
     """
-    Extract a given field from an HDF5 file in the openPMD format,
+    Extract a given field from a file in the openPMD format,
     when the geometry is thetaMode
 
     Parameters

--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/params_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/params_reader.py
@@ -1,0 +1,197 @@
+"""
+This file is part of the openPMD-viewer.
+
+It defines a function that can read standard parameters from an openPMD file.
+
+Copyright 2020, openPMD-viewer contributors
+Authors: Axel Huebl
+License: 3-Clause-BSD-LBNL
+"""
+
+import numpy as np
+from .utilities import join_infile_path
+
+
+def read_openPMD_params(series, iteration, extract_parameters=True):
+    """
+    Extract the time and some openPMD parameters from a file
+
+    Parameter
+    ---------
+    series: openpmd_api.Series
+        An open, readable openPMD-api series object
+
+    iteration: integer
+        Iteration from which parameters should be extracted
+
+    extract_parameters: bool, optional
+        Whether to extract all parameters or only the time
+        (Function execution is faster when extract_parameters is False)
+
+    Returns
+    -------
+    A tuple with:
+    - A float corresponding to the time of this iteration in SI units
+    - A dictionary containing several parameters, such as the geometry, etc.
+      When extract_parameters is False, the second argument returned is None.
+    """
+    it = series.iterations[iteration]
+
+    # extract the time
+    t = it.time() * it.time_unit_SI()
+
+    # If the user did not request more parameters, close file and exit
+    if not extract_parameters:
+        return t, None
+
+    # Otherwise, extract the rest of the parameters
+    params = {}
+
+    # Find out supported openPMD extensions claimed by this file
+    # note: a file might implement multiple extensions
+    known_extensions = {'ED-PIC': np.uint32(1)}
+    bitmask_all_extensions = series.openPMD_extension
+    params['extensions'] = []
+    for extension, bitmask in known_extensions.items():
+        # This uses a bitmask to identify activated extensions
+        # efficiently in static programming languages via
+        # a single attribute and a binary AND (&) operation.
+        # Standard: https://git.io/vwnMw
+        # Bitmasks: https://en.wikipedia.org/wiki/Mask_%28computing%29
+        if bitmask_all_extensions & bitmask == bitmask:
+            params['extensions'].append(extension)
+
+    # Find out whether fields are present and extract their metadata
+    fields_available = len(it.meshes) > 0
+    if fields_available:
+        params['avail_fields'] = []
+        params['fields_metadata'] = {}
+
+        # Loop through the available fields
+        for field_name, field in it.meshes.items():
+            metadata = {}
+            metadata['geometry'] = field.get_attribute('geometry')
+            metadata['axis_labels'] = field.axis_labels
+
+            # Swap the order of the labels if the code that wrote the HDF5 file
+            # was Fortran order (i.e. reverse order with respect to Python)
+            if field.get_attribute('dataOrder') == 'F':
+                metadata['axis_labels'] = metadata['axis_labels'][::-1]
+            # Check whether the field is a vector or a scalar
+            if field.scalar:
+                metadata['type'] = 'scalar'
+            else:
+                metadata['type'] = 'vector'
+            # Check the number of modes
+            if metadata['geometry'] == "thetaMode":
+                # simply check first record component
+                field_component = next(field.items())[1]
+                Nm = field_component.ndim
+                metadata['avail_circ_modes'] = ['all'] + \
+                    [str(m) for m in range(int(Nm / 2) + 1)]
+            # Check if this a 1d, 2d or 3d Cartesian
+            elif metadata['geometry'] == "cartesian":
+                dim = len(metadata['axis_labels'])
+                if dim == 1:
+                    metadata['geometry'] = "1dcartesian"
+                elif dim == 2:
+                    metadata['geometry'] = "2dcartesian"
+                elif dim == 3:
+                    metadata['geometry'] = "3dcartesian"
+                metadata['avail_circ_modes'] = []
+
+            params['avail_fields'].append( field_name )
+            params['fields_metadata'][field_name] = metadata
+
+    else:
+        params['avail_fields'] = None
+
+    # Find out whether particles are present, and if yes of which species
+    particles_available = len(it.particles) > 0
+    if particles_available:
+        # Particles are present ; extract the species
+        params['avail_species'] = list(it.particles)
+        # dictionary with list of record components for each species
+        record_components = {}
+        # Go through all species
+        # TODO: I did this more elegant in ParaView... for later
+        for species_name, species in it.particles.items():
+            record_components[species_name] = []
+
+            # Go through all the particle records of this species
+            for record_name, record in species.items():
+                # Skip the particlePatches, which are not used here.
+                # API should filter this...
+                # if record_name == 'particlePatches':
+                #     continue
+                if record.scalar:
+                    # Add the name of the scalar record
+                    record_components[species_name]. \
+                        append(record_name)
+                else:
+                    # Add each component of the vector record
+                    for compo_name in list(record):
+                        record_components[species_name]. \
+                            append(join_infile_path(record_name, compo_name))
+            # Simplify the name of some standard openPMD records
+            record_components[species_name] = \
+                simplify_record(record_components[species_name])
+        params['avail_record_components'] = record_components
+        # deprecated
+        first_species_name = next(iter(params['avail_species']))
+        params['avail_ptcl_quantities'] = \
+            record_components[first_species_name]
+    else:
+        # Particles are absent
+        params['avail_species'] = None
+        params['avail_record_components'] = None
+        # deprecated
+        params['avail_ptcl_quantities'] = None
+
+    return t, params
+
+
+def simplify_record(record_comps):
+    """
+    Replace the names of some standard record by shorter names
+
+    Parameter
+    ---------
+    record_comps: a list of strings
+        A list of available particle record components
+
+    Returns
+    -------
+    A list with shorter names, where applicable
+    """
+    # Replace the names of the positions
+    if ('position/x' in record_comps) and ('positionOffset/x' in record_comps):
+        record_comps.remove('position/x')
+        record_comps.remove('positionOffset/x')
+        record_comps.append('x')
+    if ('position/y' in record_comps) and ('positionOffset/y' in record_comps):
+        record_comps.remove('position/y')
+        record_comps.remove('positionOffset/y')
+        record_comps.append('y')
+    if ('position/z' in record_comps) and ('positionOffset/z' in record_comps):
+        record_comps.remove('position/z')
+        record_comps.remove('positionOffset/z')
+        record_comps.append('z')
+
+    # Replace the names of the momenta
+    if 'momentum/x' in record_comps:
+        record_comps.remove('momentum/x')
+        record_comps.append('ux')
+    if 'momentum/y' in record_comps:
+        record_comps.remove('momentum/y')
+        record_comps.append('uy')
+    if 'momentum/z' in record_comps:
+        record_comps.remove('momentum/z')
+        record_comps.append('uz')
+
+    # Replace the name for 'weights'
+    if 'weighting' in record_comps:
+        record_comps.remove('weighting')
+        record_comps.append('w')
+
+    return record_comps

--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/particle_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/particle_reader.py
@@ -1,0 +1,101 @@
+"""
+This file is part of the openPMD-viewer.
+
+It defines a function that reads a species record component (data & meta)
+from an openPMD file
+
+Copyright 2020, openPMD-viewer contributors
+Authors: Axel Huebl
+License: 3-Clause-BSD-LBNL
+"""
+
+import numpy as np
+from scipy import constants
+from .utilities import get_data
+
+
+def read_species_data(series, iteration, species_name, component_name,
+                      extensions):
+    """
+    Extract a given species' record_comp
+
+    Parameters
+    ----------
+    series: openpmd_api.Series
+        An open, readable openPMD-api series object
+
+    iteration: integer
+        Iteration from which parameters should be extracted
+
+    species_name: string
+        The name of the species to extract (in the openPMD file)
+
+    component_name: string
+        The record component to extract
+        Either 'x', 'y', 'z', 'ux', 'uy', 'uz', or 'w'
+
+    extensions: list of strings
+        The extensions that the current OpenPMDTimeSeries complies with
+    """
+    it = series.iterations[iteration]
+
+    # Translate the record component to the openPMD format
+    dict_record_comp = {'x': ['position', 'x'],
+                        'y': ['position', 'y'],
+                        'z': ['position', 'z'],
+                        'ux': ['momentum', 'x'],
+                        'uy': ['momentum', 'y'],
+                        'uz': ['momentum', 'z'],
+                        'w': ['weighting', None]}
+    
+    if component_name in dict_record_comp:
+        ompd_record_name, ompd_record_comp_name = \
+            dict_record_comp[component_name]
+    elif component_name.find('/') != -1:
+        ompd_record_name, ompd_record_comp_name = \
+            component_name.split('/')
+    else:
+        ompd_record_name = component_name
+        ompd_record_comp_name = None
+
+    # Extract the right dataset
+    species = it.particles[species_name]
+    record = species[ompd_record_name]
+    if record.scalar:
+        component = next(record.items())[1]
+    else:
+        component = record[ompd_record_comp_name]
+
+    if ompd_record_name == 'id':
+        output_type = np.uint64
+    else:
+        output_type = np.float64
+    data = get_data( series, component, output_type=output_type )
+
+    # For ED-PIC: if the data is weighted for a full macroparticle,
+    # divide by the weight with the proper power
+    # (Skip this if the current record component is the weight itself)
+    if 'ED-PIC' in extensions and ompd_record_name != 'weighting':
+        macro_weighted = record.get_attribute('macroWeighted')
+        weighting_power = record.get_attribute('weightingPower')
+        if (macro_weighted == 1) and (weighting_power != 0):
+            w_component = next(species['weighting'].items())[1]
+            w = get_data( w_component )
+            data *= w ** (-weighting_power)
+
+    # - Return positions, with an offset
+    if component_name in ['x', 'y', 'z']:
+        offset = get_data(series, species['positionOffset'][component_name])
+        data += offset
+    # - Return momentum in normalized units
+    elif component_name in ['ux', 'uy', 'uz' ]:
+        mass_component = next(species['mass'].items())[1]
+        m = get_data(series, mass_component)
+        # Normalize only if the particle mass is non-zero
+        if np.all( m != 0 ):
+            norm_factor = 1. / (m * constants.c)
+            data *= norm_factor
+
+
+    # Return the data
+    return data

--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/utilities.py
@@ -1,0 +1,99 @@
+"""
+This file is part of the openPMD-viewer.
+
+It defines a set of helper data and functions which
+are used by the other files.
+
+Copyright 2015-2016, openPMD-viewer contributors
+Authors: Remi Lehe, Axel Huebl
+License: 3-Clause-BSD-LBNL
+"""
+import numpy as np
+
+
+def get_data(series, record_component, i_slice=None, pos_slice=None,
+             output_type=np.float64):
+    """
+    Extract the data from a (possibly constant) dataset
+    Slice the data according to the parameters i_slice and pos_slice
+
+    Parameters:
+    -----------
+    series: openpmd_api.Series
+        An open, readable openPMD-api series object
+
+    record_component: an openPMD.Record_Component
+
+    pos_slice: int or list of int, optional
+        Slice direction(s).
+        When None, no slicing is performed
+
+    i_slice: int or list of int, optional
+       Indices of slices to be taken.
+
+    output_type: a numpy type
+       The type to which the returned array should be converted
+
+    Returns:
+    --------
+    An np.ndarray (non-constant dataset) or a single double (constant dataset)
+    """
+    # For back-compatibility: Convert pos_slice and i_slice to
+    # single-element lists if they are not lists (e.g. float
+    # and int respectively).
+    if pos_slice is not None and not isinstance(pos_slice, list):
+        pos_slice = [pos_slice]
+    if i_slice is not None and not isinstance(i_slice, list):
+        i_slice = [i_slice]
+
+    if pos_slice is None:
+        data = record_component[()]
+    else:
+        # Get largest element of pos_slice
+        max_pos = max(pos_slice)
+        # Create list of indices list_index of type
+        # [:, :, :, ...] where Ellipsis starts at max_pos + 1
+        list_index = [np.s_[:]] * (max_pos + 2)
+        list_index[max_pos + 1] = np.s_[...]
+        # Fill list_index with elements of i_slice
+        for count, dir_index in enumerate(pos_slice):
+            list_index[dir_index] = i_slice[count]
+        # Convert list_index into a tuple
+        tuple_index = tuple(list_index)
+        # Slice dset according to tuple_index
+        data = record_component[tuple_index]
+
+    series.flush()
+
+    # Convert to the right type
+    if data.dtype != output_type:
+        data = data.astype( output_type )
+    # Scale by the conversion factor
+    if output_type in [ np.float64, np.float32, np.float16 ]:
+        if record_component.unit_SI != 1.0:
+            data *= record_component.unit_SI
+
+    return data
+
+
+def join_infile_path(*paths):
+    """
+    Join path components using '/' as separator.
+    This method is defined as an alternative to os.path.join, which uses '\\'
+    as separator in Windows environments and is therefore not valid to navigate
+    within data files.
+
+    Parameters:
+    -----------
+    *paths: all strings with path components to join
+
+    Returns:
+    --------
+    A string with the complete path using '/' as separator.
+    """
+    # Join path components
+    path = '/'.join(paths)
+    # Correct double slashes, if any is present
+    path = path.replace('//', '/')
+
+    return path

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,8 @@ setup(name='openPMD-viewer',
       extras_require = {
         'GUI':  ["ipywidgets", "matplotlib"],
         'plot': ["matplotlib"],
-        'tutorials': ["ipywidgets", "matplotlib", "wget"]
+        'tutorials': ["ipywidgets", "matplotlib", "wget"],
+        'openpmd-api': ["openpmd-api"]
         },
       cmdclass={'test': PyTest},
       platforms='any',


### PR DESCRIPTION
Action items:
- [x] @ax3l: Implement openPMD-api backend 
- [x] @RemiLehe: Split off the first part of this PR (i.e. isolating `h5py` specific code into a separate folder) into a separate PR: #289
- [x] @ax3l: Rebase this PR once the above-mentioned split-off is done and merged
- [x] Add an installation target so that we can do automatically install the `openpmd-api` backend with `pip install openpmd-viewer[openpmd-api]` (specific syntax is up for discussion :) )
- [ ] add `openpmd_viewer.backend()` function to query active file backend
- [x] remove `openpmd_api` package in one of the matrix entries on travis (so we have continued `h5py` coverage)

Future:
- file-handle management. pro-actively close oldest open files to avoid running into ulimits: https://github.com/openPMD/openPMD-api/pull/822