### PR TITLE
test preparation: regex r"string"

### DIFF
--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -68,20 +68,20 @@ def clean_ipython_features(script_name):
 
         # Replace the lines that activate matplotlib in a notebook
         # by a line that selects the PS backend
-        if re.search("get_ipython.*matplotlib", lines[i]) is not None:
+        if re.search(r"get_ipython.*matplotlib", lines[i]) is not None:
             lines[i] = "import matplotlib; matplotlib.use('ps')\n"
 
         # Discard the lines that use in-notebook documentation
-        if re.search("get_ipython.*pinfo", lines[i]) is not None:
+        if re.search(r"get_ipython.*pinfo", lines[i]) is not None:
             lines[i] = ''
 
         # Discard the lines that use the GUI
-        if re.match("[\w]*\.slider", lines[i]) is not None:
+        if re.match(r"[\w]*\.slider", lines[i]) is not None:
             lines[i] = ''
 
         # Replace the lines that call the OS by proper lines
-        if re.match("[ ]*get_ipython\(\)\.system", lines[i]) is not None:
-            matched = re.match("([ ]*)get_ipython\(\)\.system(.*)", lines[i])
+        if re.match(r"[ ]*get_ipython\(\)\.system", lines[i]) is not None:
+            matched = re.match(r"([ ]*)get_ipython\(\)\.system(.*)", lines[i])
             spaces = matched.groups()[0]
             command_line = matched.groups()[1]
             lines[i] = '%simport os; os.system%s\n' % (spaces, command_line)


### PR DESCRIPTION
I got a warning that the regex expressions are not recognized in Python 3.8.5. This led to problems as the regex were not applied when generating `.py` files for automatic testing on the fly.