### PR TITLE
Add a new variable `openpmd_viewer.backend`

### DIFF
--- a/openpmd_viewer/__init__.py
+++ b/openpmd_viewer/__init__.py
@@ -7,9 +7,9 @@ See the class OpenPMDTimeSeries to open a set of openPMD files
 """
 # Make the OpenPMDTimeSeries object accessible from outside the package
 from .openpmd_timeseries import OpenPMDTimeSeries, FieldMetaInformation, \
-    ParticleTracker
+    ParticleTracker, backend
 
 # Define the version number
 from .__version__ import __version__
 __all__ = ['OpenPMDTimeSeries', 'FieldMetaInformation',
-           'ParticleTracker', '__version__']
+           'ParticleTracker', 'backend', '__version__']

--- a/openpmd_viewer/openpmd_timeseries/__init__.py
+++ b/openpmd_viewer/openpmd_timeseries/__init__.py
@@ -1,4 +1,6 @@
 # Make the OpenPMDTimeSeries accessible from outside the file main
 from .main import OpenPMDTimeSeries, ParticleTracker
+from .data_reader import backend
 from .field_metainfo import FieldMetaInformation
-__all__ = ['OpenPMDTimeSeries', 'FieldMetaInformation', 'ParticleTracker']
+__all__ = ['OpenPMDTimeSeries', 'FieldMetaInformation',
+            'ParticleTracker', 'backend']

--- a/openpmd_viewer/openpmd_timeseries/data_reader/__init__.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/__init__.py
@@ -1,2 +1,2 @@
-from .data_reader import DataReader
-__all__ = ['DataReader']
+from .data_reader import DataReader, backend
+__all__ = ['DataReader', 'backend']


### PR DESCRIPTION
With this new variable, the user can now check the backend that is being used:
```py
import openpmd_viewer
print( openpmd_viewer.backend )
```