### PR TITLE
Fix bug in refactored reader when reading scalar fields

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/main.py
+++ b/openpmd_viewer/openpmd_timeseries/main.py
@@ -444,7 +444,7 @@ class OpenPMDTimeSeries(InteractiveViewer):
                     'The `slice_across` argument is erroneous: contains %s\n'
                     'The available axes are: \n - %s' % (axis, axes_list) )
 
-        # Check the coordinate (for vector fields)
+        # Check the coordinate, for vector fields
         if self.fields_metadata[field]['type'] == 'vector':
             available_coord = ['x', 'y', 'z']
             if self.fields_metadata[field]['geometry'] == 'thetaMode':
@@ -456,6 +456,10 @@ class OpenPMDTimeSeries(InteractiveViewer):
                     "argument is missing or erroneous.\nThe available "
                     "coordinates are: \n - %s\nPlease set the `coord` "
                     "argument accordingly." % (field, coord_list))
+        # Automatically set the coordinate to None, for scalar fields
+        else:
+            coord = None
+
         # Check the mode (for thetaMode)
         if self.fields_metadata[field]['geometry'] == "thetaMode":
             avail_circ_modes = self.fields_metadata[field]['avail_circ_modes']


### PR DESCRIPTION
The refactored reader (#289) is crashing when the user passes a non-`None` `coord` for a scalar field, e.g.:
```
ts.get_field( field='rho', coord='x')
```
instead of 
```
ts.get_field( field='rho' )    # here, by default coord=None
```

While passing a non-`None` value for `coord` is here somewhat inconsistent, the previous reader (before #289) was robust to this and was naturally ignoring `coord` in the case of scalar fields. 
This PR recovers this previous behavior.