### PR TITLE
CI: conda create at once

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -27,8 +27,8 @@ jobs:
       name: Setup conda
       with:
         auto-update-conda: true
-        python-version: ${{ matrix.python-version }}
         activate-environment: testing
+        auto-activate-base: false
         channels: conda-forge,defaults
         channel-priority: true
 
@@ -36,9 +36,9 @@ jobs:
       name: Install dependencies
       run: |
         if [ "${{ matrix.python-version }}" != "3.8" ]; then
-          conda install --yes cython numpy scipy h5py openpmd-api matplotlib jupyter pytest pyflakes python-wget
+          conda install --yes cython numpy scipy h5py openpmd-api matplotlib jupyter pytest pyflakes python=${{ matrix.python-version }} python-wget
         else
-          conda install --yes cython numpy scipy h5py matplotlib jupyter pytest pyflakes python-wget
+          conda install --yes cython numpy scipy h5py matplotlib jupyter pytest pyflakes python=${{ matrix.python-version }} python-wget 
         fi
 
     - shell: bash -l {0}


### PR DESCRIPTION
Create the conda environment at once, since upgrading with an existing environment, even if it only contains only a python, confuses the conda concretizer and sometimes finds package solutions using old releases of openPMD-api.

Simply put: `conda create -n <env>` instead of `conda install ...`.
Details here: we create an empty env and install all at once (just because the GH action is like this).

An alternative would be to use `mamba`, which has a great, modern concretizer.

Also skip activation of base environment.
From the readme of the GH action:
```
disable autoactivating the base environment before activating the `anaconda-client-env`
```
https://github.com/conda-incubator/setup-miniconda/tree/11e3f4eb00d47684d31b2172efd04a9326dfd479#example-3-other-options