### PR TITLE
API: Anticipate Backend API Change

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/params_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/params_reader.py
@@ -38,7 +38,10 @@ def read_openPMD_params(series, iteration, extract_parameters=True):
     it = series.iterations[iteration]
 
     # extract the time
-    t = it.time() * it.time_unit_SI()
+    if callable(it.time):  # prior to openPMD-api 0.13.0
+        t = it.time() * it.time_unit_SI()
+    else:
+        t = it.time * it.time_unit_SI
 
     # If the user did not request more parameters, close file and exit
     if not extract_parameters:


### PR DESCRIPTION
I plan to fix an inconsistency in the Python API for the `Iteration` object properties. This change anticipates the break in a backward and forward compatible (openPMD-api 0.13.0+) manner.

Ref.: https://github.com/openPMD/openPMD-api/pull/859