### PR TITLE
Add method to calculate central energy and energy spread

### DIFF
--- a/openpmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/openpmd_viewer/addons/pic/lpa_diagnostics.py
@@ -134,6 +134,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             p_width = w_mad(prop, w)
         else:
             raise ValueError('Invalid width property: %s' % width)
+
         return p_center, p_width
 
     def get_mean_gamma( self, t=None, iteration=None, species=None,

--- a/openpmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/openpmd_viewer/addons/pic/lpa_diagnostics.py
@@ -1160,7 +1160,7 @@ def w_mad(a, w):
         """
     med = w_median(a, w)
     mad = w_median(np.abs(a - med), w)
-    return med, mad
+    return mad
 
 def gaussian_profile( x, x0, E0, w0 ):
     """

--- a/openpmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/openpmd_viewer/addons/pic/lpa_diagnostics.py
@@ -1116,18 +1116,18 @@ def w_std( a, weights ):
 
 def w_median(a, weights):
     """
-        Compute the weighted median of a 1D numpy array.
-        Parameters
-        ----------
-        a : ndarray
-            Input array (one dimension).
-        weights : ndarray
-            Array with the weights of the same size of `data`.
-        Returns
-        -------
-        median : float
-            The output value.
-        """
+    Compute the weighted median of a 1D numpy array.
+    Parameters
+    ----------
+    a : ndarray
+        Input array (one dimension).
+    weights : ndarray
+        Array with the weights of the same size of `data`.
+    Returns
+    -------
+    median : float
+        The output value.
+    """
     quantile = .5
     if not isinstance(a, np.matrix):
         a = np.asarray(a)

--- a/openpmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/openpmd_viewer/addons/pic/lpa_diagnostics.py
@@ -1131,8 +1131,6 @@ def w_median(a, weights):
         a = np.asarray(a)
     if not isinstance(weights, np.matrix):
         weights = np.asarray(weights)
-    nd = a.ndim
-    ndw = weights.ndim
     if a.shape != weights.shape:
         raise TypeError("the length of data and weights must be the same")
     ind_sorted = np.argsort(a)

--- a/openpmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/openpmd_viewer/addons/pic/lpa_diagnostics.py
@@ -118,6 +118,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             prop = gamma
         else:
             raise ValueError('Invalid output property: %s'%property)
+
         # Calculate weighted center
         if center == 'mean':
             p_center = w_ave(prop, w)

--- a/openpmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/openpmd_viewer/addons/pic/lpa_diagnostics.py
@@ -1146,18 +1146,18 @@ def w_median(a, weights):
 
 def w_mad(a, w):
     """
-        Compute the weighted median absolute deviation of a 1D numpy array.
-        Parameters
-        ----------
-        a : ndarray
-            Input array (one dimension).
-        weights : ndarray
-            Array with the weights of the same size of `data`.
-        Returns
-        -------
-        mad : float
-            The output value.
-        """
+    Compute the weighted median absolute deviation of a 1D numpy array.
+    Parameters
+    ----------
+    a : ndarray
+        Input array (one dimension).
+    weights : ndarray
+        Array with the weights of the same size of `data`.
+    Returns
+    -------
+    mad : float
+        The output value.
+    """
     med = w_median(a, w)
     mad = w_median(np.abs(a - med), w)
     return mad

--- a/openpmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/openpmd_viewer/addons/pic/lpa_diagnostics.py
@@ -1140,6 +1140,7 @@ def w_median(a, weights):
     sorted_weights = weights[ind_sorted]
 
     Sn = np.cumsum(sorted_weights)
+    # Center and normalize the cumsum (i.e. divide by the total sum)
     Pn = (Sn - 0.5 * sorted_weights) / Sn[-1]
     # Get the value of the weighted median
     return np.interp(quantile, Pn, sorted_data)

--- a/openpmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/openpmd_viewer/addons/pic/lpa_diagnostics.py
@@ -126,6 +126,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             p_center = w_median(prop, w)
         else:
             raise ValueError('Invalid center property: %s' % center)
+
         # Calculate weighted width
         if width == 'std':
             p_width = w_std(prop, w)

--- a/openpmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/openpmd_viewer/addons/pic/lpa_diagnostics.py
@@ -111,10 +111,9 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
             species=species, t=t, iteration=iteration)
         # Calculate Lorentz factor and energy for all particles
         gamma = np.sqrt(1 + ux ** 2 + uy ** 2 + uz ** 2)
-        energy = (gamma - 1) * m * const.c ** 2 / const.e * 1e-6
-
         if property == 'energy':
-            prop = energy
+            prop = (gamma - 1) * m * const.c ** 2 / const.e * 1e-6
+
         elif property == 'gamma':
             prop = gamma
         else:


### PR DESCRIPTION
Hi,
I've added a method to calculate the central energy and the energy spread of a particle distribution via mean and standard deviation or median and median absolute deviation.
This is in part redundant with `get_mean_gamma` which I left for backward compatibility.