### PR TITLE
Add support for fields with cylindrical geometry in DataReader

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/field_reader.py
@@ -122,7 +122,7 @@ def read_field_circ( filename, iteration, field, coord,
                      slice_relative_position, slice_across, m=0, theta=0. ):
     """
     Extract a given field from an HDF5 file in the openPMD format,
-    when the geometry is thetaMode
+    when the geometry is thetaMode or cylindrical
 
     Parameters
     ----------

--- a/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/params_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/params_reader.py
@@ -115,6 +115,9 @@ def read_openPMD_params(filename, iteration, extract_parameters=True):
                 elif dim == 3:
                     metadata['geometry'] = "3dcartesian"
                 metadata['avail_circ_modes'] = []
+            # Check if is cylindrical
+            elif metadata['geometry'] == "cylindrical":
+                metadata['avail_circ_modes'] = []
 
             params['avail_fields'].append( field_name )
             params['fields_metadata'][field_name] = metadata

--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/field_reader.py
@@ -123,7 +123,7 @@ def read_field_circ( series, iteration, field_name, component_name,
                      slice_relative_position, slice_across, m=0, theta=0. ):
     """
     Extract a given field from a file in the openPMD format,
-    when the geometry is thetaMode
+    when the geometry is thetaMode or cylindrical
 
     Parameters
     ----------

--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/params_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/params_reader.py
@@ -102,6 +102,9 @@ def read_openPMD_params(series, iteration, extract_parameters=True):
                 elif dim == 3:
                     metadata['geometry'] = "3dcartesian"
                 metadata['avail_circ_modes'] = []
+            # Check if is cylindrical
+            elif metadata['geometry'] == "cylindrical":
+                metadata['avail_circ_modes'] = []
 
             params['avail_fields'].append( field_name )
             params['fields_metadata'][field_name] = metadata


### PR DESCRIPTION
Currently the `read_field_circ` method of the `DataReader` fails for fields with cylindrical geometry in both the `openpmd-api` and `h5py` backends. This is because the method expects a field with `thetaMode` geometry, which has a shape with three components where the first index contains the different modes. This is however not present in cylindrical data, which has a purely 2D shape. In addition, the is no ranking for cylindrical geometry in `get_grid_parameters`.

This PR fixes these issues in both backends, allowing the `DataReader` to work properly with this geometry. This has been tested in a new branch of VisualPIC, which uses the `DataReader` to access openPMD data, and everything seems to be working properly. The default tests also pass with no problem.

It is possible that there might be other parts of the code where data in cylindrical geometry could cause issues. I have seen for example that in the `lpa_diagnostics.py` or `interactive.py` the code checks for the geometry in some methods. However, I am only using the `DataReader`, so I have not tested for any problems outside of it.

Edit: sample diagnostics in cylindrical geometry. Download [here](https://desycloud.desy.de/index.php/s/egkbx69QG298mpN). Note that the fist iteration does not have fields.