### PR TITLE
Add list of available components to field metadata

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/params_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/params_reader.py
@@ -94,8 +94,12 @@ def read_openPMD_params(filename, iteration, extract_parameters=True):
             # Check whether the field is a vector or a scalar
             if is_scalar_record(field):
                 metadata['type'] = 'scalar'
+                components = []
             else:
                 metadata['type'] = 'vector'
+                components = list(field.keys())
+            # Register available components
+            metadata['avail_components'] = components
             # Check the number of modes
             if metadata['geometry'] == "thetaMode":
                 if is_scalar_record(field):

--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/params_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/params_reader.py
@@ -83,8 +83,12 @@ def read_openPMD_params(series, iteration, extract_parameters=True):
             # Check whether the field is a vector or a scalar
             if field.scalar:
                 metadata['type'] = 'scalar'
+                components = []
             else:
                 metadata['type'] = 'vector'
+                components = [comp for comp, _ in field.items()]
+            # Register available components
+            metadata['avail_components'] = components
             # Check the number of modes
             if metadata['geometry'] == "thetaMode":
                 # simply check first record component


### PR DESCRIPTION
Small PR which adds the list of available field components (`'avail_components'`) to the field metadata. Right now, as far as I know, this can only be guessed from the field geometry, but it is not a given that all possible components are actually saved to file. As usual, this is needed by VisualPIC.