### PR TITLE
Add option to limit resolution of 3D reconstruction of thetaMode fields

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/data_reader/data_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/data_reader.py
@@ -190,7 +190,7 @@ class DataReader( object ):
                 slice_relative_position, slice_across )
 
     def read_field_circ( self, iteration, field, coord, slice_relative_position,
-                        slice_across, m=0, theta=0. ):
+                        slice_across, m=0, theta=0., max_resolution_3d=None ):
         """
         Extract a given field from an openPMD file in the openPMD format,
         when the geometry is thetaMode
@@ -241,11 +241,11 @@ class DataReader( object ):
             filename = self.iteration_to_file[iteration]
             return h5py_reader.read_field_circ(
                 filename, iteration, field, coord, slice_relative_position,
-                slice_across, m, theta )
+                slice_across, m, theta, max_resolution_3d )
         elif self.backend == 'openpmd-api':
             return io_reader.read_field_circ(
                 self.series, iteration, field, coord, slice_relative_position,
-                slice_across, m, theta )
+                slice_across, m, theta, max_resolution_3d )
 
     def read_species_data( self, iteration, species, record_comp, extensions):
         """

--- a/openpmd_viewer/openpmd_timeseries/data_reader/data_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/data_reader.py
@@ -229,6 +229,13 @@ class DataReader( object ):
            0 : middle of the simulation box
            1 : upper edge of the simulation box
 
+        max_resolution_3d : list of int or None
+            Maximum resolution that the 3D reconstruction of the field (when
+            `theta` is None) can have. The list should contain two values,
+            e.g. `[200, 100]`, indicating the maximum longitudinal and
+            transverse resolution, respectively. This is useful for
+            performance reasons, particularly for 3D visualization.
+
         Returns
         -------
         A tuple with

--- a/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/field_reader.py
@@ -160,6 +160,13 @@ def read_field_circ( filename, iteration, field, coord,
        0 : middle of the simulation box
        1 : upper edge of the simulation box
 
+    max_resolution_3d : list of int or None
+        Maximum resolution that the 3D reconstruction of the field (when
+        `theta` is None) can have. The list should contain two values,
+        e.g. `[200, 100]`, indicating the maximum longitudinal and transverse
+        resolution, respectively. This is useful for performance reasons,
+        particularly for 3D visualization.
+
     Returns
     -------
     A tuple with

--- a/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/field_reader.py
@@ -219,7 +219,7 @@ def read_field_circ( filename, iteration, field, coord,
             if nr > max_res_transv/2:
                 # Calculate excess of elements along r
                 excess_r = int(np.round(nr/(max_res_transv/2)))
-                # Preserve only one every excess_z elements
+                # Preserve only one every excess_r elements
                 Fcirc = Fcirc[:, ::excess_r, :]
                 # Update info and necessary parameters accordingly
                 info.r = info.r[::excess_r]

--- a/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/field_reader.py
@@ -119,7 +119,8 @@ def read_field_cartesian( filename, iteration, field, coord, axis_labels,
 
 
 def read_field_circ( filename, iteration, field, coord,
-                     slice_relative_position, slice_across, m=0, theta=0. ):
+                     slice_relative_position, slice_across, m=0, theta=0.,
+                     max_resolution_3d=None ):
     """
     Extract a given field from an HDF5 file in the openPMD format,
     when the geometry is thetaMode
@@ -196,6 +197,28 @@ def read_field_circ( filename, iteration, field, coord,
             modes = [ m ]
         modes = np.array( modes, dtype='int' )
         nmodes = len(modes)
+
+        # If necessary, reduce resolution of 3D reconstruction
+        if max_resolution_3d is not None:
+            max_res_lon, max_res_transv = max_resolution_3d
+            if Nz > max_res_lon:
+                # Calculate excess of elements along z
+                excess_z = int(np.round(Nz/max_res_lon))
+                # Preserve only one every excess_z elements
+                Fcirc = Fcirc[:, :, ::excess_z]
+                # Update info accordingly
+                info.z = info.z[::excess_z]
+                info.dz = info.z[1] - info.z[0]
+            if nr > max_res_transv/2:
+                # Calculate excess of elements along r
+                excess_r = int(np.round(nr/(max_res_transv/2)))
+                # Preserve only one every excess_z elements
+                Fcirc = Fcirc[:, ::excess_r, :]
+                # Update info and necessary parameters accordingly
+                info.r = info.r[::excess_r]
+                info.dr = info.r[1] - info.r[0]
+                inv_dr = 1./info.dr
+                nr = Fcirc.shape[1]
 
         # Convert cylindrical data to Cartesian data
         info._convert_cylindrical_to_3Dcartesian()

--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/field_reader.py
@@ -161,6 +161,13 @@ def read_field_circ( series, iteration, field_name, component_name,
        0 : middle of the simulation box
        1 : upper edge of the simulation box
 
+    max_resolution_3d : list of int or None
+        Maximum resolution that the 3D reconstruction of the field (when
+        `theta` is None) can have. The list should contain two values,
+        e.g. `[200, 100]`, indicating the maximum longitudinal and transverse
+        resolution, respectively. This is useful for performance reasons,
+        particularly for 3D visualization.
+
     Returns
     -------
     A tuple with

--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/field_reader.py
@@ -120,7 +120,8 @@ def read_field_cartesian( series, iteration, field_name, component_name,
 
 
 def read_field_circ( series, iteration, field_name, component_name,
-                     slice_relative_position, slice_across, m=0, theta=0. ):
+                     slice_relative_position, slice_across, m=0, theta=0.,
+                     max_resolution_3d=None ):
     """
     Extract a given field from a file in the openPMD format,
     when the geometry is thetaMode
@@ -199,6 +200,28 @@ def read_field_circ( series, iteration, field_name, component_name,
             modes = [ m ]
         modes = np.array( modes, dtype='int' )
         nmodes = len(modes)
+
+        # If necessary, reduce resolution of 3D reconstruction
+        if max_resolution_3d is not None:
+            max_res_lon, max_res_transv = max_resolution_3d
+            if Nz > max_res_lon:
+                # Calculate excess of elements along z
+                excess_z = int(np.round(Nz/max_res_lon))
+                # Preserve only one every excess_z elements
+                Fcirc = Fcirc[:, :, ::excess_z]
+                # Update info accordingly
+                info.z = info.z[::excess_z]
+                info.dz = info.z[1] - info.z[0]
+            if nr > max_res_transv/2:
+                # Calculate excess of elements along r
+                excess_r = int(np.round(nr/(max_res_transv/2)))
+                # Preserve only one every excess_z elements
+                Fcirc = Fcirc[:, ::excess_r, :]
+                # Update info and necessary parameters accordingly
+                info.r = info.r[::excess_r]
+                info.dr = info.r[1] - info.r[0]
+                inv_dr = 1./info.dr
+                nr = Fcirc.shape[1]
 
         # Convert cylindrical data to Cartesian data
         info._convert_cylindrical_to_3Dcartesian()

--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/field_reader.py
@@ -222,7 +222,7 @@ def read_field_circ( series, iteration, field_name, component_name,
             if nr > max_res_transv/2:
                 # Calculate excess of elements along r
                 excess_r = int(np.round(nr/(max_res_transv/2)))
-                # Preserve only one every excess_z elements
+                # Preserve only one every excess_r elements
                 Fcirc = Fcirc[:, ::excess_r, :]
                 # Update info and necessary parameters accordingly
                 info.r = info.r[::excess_r]


### PR DESCRIPTION
This PR proposes adding a parameter to `read_field_circ` for limiting the resolution of the 3D reconstructed fields when `theta=None`. Currently, the longitudinal and transverse resolution of the 3D reconstruction is the same as in the thetaMode fields, leading to very large memory usage and reconstruction time when using high-resolution data. This can be quite impractical for 3D data visualization.

Here, a `max_resolution_3d` parameter is added which allows the user to specify a list (e.g. `max_resolution_3d=[200, 100]`) containing the maximum longitudinal and transverse resolution that the 3D field should have, allowing for a significant performance gain.