### PR TITLE
3d from circ interp

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/utilities.py
@@ -311,21 +311,20 @@ def construct_3d_from_circ( F3d, Fcirc, x_array, y_array, modes,
             r = np.sqrt( x**2 + y**2 )
             ir = nr - 1 - int( (rmax - r) * inv_dr + 0.5 )
 
-            # Calculate linear projection of the field
-            if ir>0:
-                s0 = ir + 0.5 - r* inv_dr
-                s1 = 1. - s0
-            else:
-                s0 = 0
-                s1 = 1.
-
-            Fcirc_proj = s1 * Fcirc[:, ir, :] + s0 * Fcirc[:, ir-1, :]
-
             # Handle out-of-bounds
             if ir < 0:
                 ir = 0
             if ir >= nr:
                 ir = nr-1
+
+            # Calculate linear projection of the field
+            if ir>0:
+                s0 = ir + 0.5 - r* inv_dr
+                s1 = 1. - s0
+                Fcirc_proj = s1*Fcirc[:, ir, :] + s0*Fcirc[:, ir-1, :]
+            else:
+                Fcirc_proj = Fcirc[:, ir, :]
+
             # Loop over all modes and recontruct data
             if r == 0:
                 expItheta = 1. + 0.j
@@ -335,9 +334,9 @@ def construct_3d_from_circ( F3d, Fcirc, x_array, y_array, modes,
             for im in range(nmodes):
                 mode = modes[im]
                 if mode==0:
-                    F3d[ix, iy, :] += Fcirc_proj[0]
+                    F3d[ix, iy, :] += Fcirc_proj[0, :]
                 else:
                     cos = (expItheta**mode).real
                     sin = (expItheta**mode).imag
-                    F3d[ix, iy, :] += Fcirc_proj[2*mode-1]*cos + \
-                        Fcirc_proj[2*mode]*sin
+                    F3d[ix, iy, :] += Fcirc_proj[2*mode-1,:]*cos + \
+                        Fcirc_proj[2*mode,:]*sin

--- a/openpmd_viewer/openpmd_timeseries/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/utilities.py
@@ -310,6 +310,14 @@ def construct_3d_from_circ( F3d, Fcirc, x_array, y_array, modes,
             y = y_array[iy]
             r = np.sqrt( x**2 + y**2 )
             ir = nr - 1 - int( (rmax - r) * inv_dr + 0.5 )
+
+            if ir>0:
+                s0 = ir + 0.5 - r* inv_dr
+                s1 = 1. - s0
+            else:
+                s0 = 0
+                s1 = 1.
+
             # Handle out-of-bounds
             if ir < 0:
                 ir = 0
@@ -320,12 +328,19 @@ def construct_3d_from_circ( F3d, Fcirc, x_array, y_array, modes,
                 expItheta = 1. + 0.j
             else:
                 expItheta = (x+1.j*y)/r
+
+            Fcirc_proj = s1 * Fcirc[:, ir, :] + s0 * Fcirc[:, ir-1, :]
+
             for im in range(nmodes):
                 mode = modes[im]
                 if mode==0:
-                    F3d[ix, iy, :] += Fcirc[0, ir, :]
+#                    F3d[ix, iy, :] += s1 * Fcirc[0, ir, :] + s0 * Fcirc[0, ir-1, :]
+                    F3d[ix, iy, :] += Fcirc_proj[0]
                 else:
                     cos = (expItheta**mode).real
                     sin = (expItheta**mode).imag
-                    F3d[ix, iy, :] += Fcirc[2*mode-1, ir, :]*cos \
-                                    + Fcirc[2*mode, ir, :]*sin
+                    F3d[ix, iy, :] += Fcirc_proj[2*mode-1]*cos + \
+                        Fcirc_proj[2*mode]*sin
+
+#                    F3d[ix, iy, :] += (s1 * Fcirc[2*mode-1, ir, :] + s0 * Fcirc[2*mode-1, ir-1, :])*cos \
+#                                    + (s1 * Fcirc[2*mode, ir, :] + s0 * Fcirc[2*mode, ir-1, :])*sin

--- a/openpmd_viewer/openpmd_timeseries/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/utilities.py
@@ -317,7 +317,7 @@ def construct_3d_from_circ( F3d, Fcirc, x_array, y_array, modes,
             if ir >= nr:
                 ir = nr-1
 
-            # Calculate linear projection of the field
+            # Calculate linear projection from ir and ir-1
             if ir>0:
                 s0 = ir + 0.5 - r* inv_dr
                 s1 = 1. - s0

--- a/openpmd_viewer/openpmd_timeseries/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/utilities.py
@@ -311,12 +311,15 @@ def construct_3d_from_circ( F3d, Fcirc, x_array, y_array, modes,
             r = np.sqrt( x**2 + y**2 )
             ir = nr - 1 - int( (rmax - r) * inv_dr + 0.5 )
 
+            # Calculate linear projection of the field
             if ir>0:
                 s0 = ir + 0.5 - r* inv_dr
                 s1 = 1. - s0
             else:
                 s0 = 0
                 s1 = 1.
+
+            Fcirc_proj = s1 * Fcirc[:, ir, :] + s0 * Fcirc[:, ir-1, :]
 
             # Handle out-of-bounds
             if ir < 0:
@@ -329,18 +332,12 @@ def construct_3d_from_circ( F3d, Fcirc, x_array, y_array, modes,
             else:
                 expItheta = (x+1.j*y)/r
 
-            Fcirc_proj = s1 * Fcirc[:, ir, :] + s0 * Fcirc[:, ir-1, :]
-
             for im in range(nmodes):
                 mode = modes[im]
                 if mode==0:
-#                    F3d[ix, iy, :] += s1 * Fcirc[0, ir, :] + s0 * Fcirc[0, ir-1, :]
                     F3d[ix, iy, :] += Fcirc_proj[0]
                 else:
                     cos = (expItheta**mode).real
                     sin = (expItheta**mode).imag
                     F3d[ix, iy, :] += Fcirc_proj[2*mode-1]*cos + \
                         Fcirc_proj[2*mode]*sin
-
-#                    F3d[ix, iy, :] += (s1 * Fcirc[2*mode-1, ir, :] + s0 * Fcirc[2*mode-1, ir-1, :])*cos \
-#                                    + (s1 * Fcirc[2*mode, ir, :] + s0 * Fcirc[2*mode, ir-1, :])*sin


### PR DESCRIPTION
presently the method `construct_3d_from_circ` gets field value at `(x_i, y_i)` from the _upper_ cell node `r_i`. 
In some case this may provide a lower accuracy, e.g. in some particular cases the full integral of laser `Ex**2` field could differ by up to a few percents from its real value (calculated on the actual cylindrical grid). 

This PR adds a linear interpolation to this method and increases the accuracy. For example, in the default example `lwfa_script.py` modified with `Nr = 350` and `Nz = 1800` the discrepancy in the total laser energy estimate is decreased from 0.054% to 0.002%.