### PR TITLE
numpy 1.15+ / h5py 2.8+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy
+numpy~=1.15
 scipy
-h5py
+h5py>=2.8.0
 tqdm
 


### PR DESCRIPTION
Require a recent version of Numpy, such as 1.15+ (but not another major release, such as 2.0, until we can test it).

- 1.14+ (1/2018) causes h5py warnings
- 1.15+ (6/2018) is known to fix issues with scalar arrays and is required by openPMD-api anyway
- the latest release is 1.20.2

h5py 2.8.0 was released (5/2018) and the latest release is 3.2.1.

Fix #230