### PR TITLE
typo in energy units

### DIFF
--- a/openpmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/openpmd_viewer/addons/pic/lpa_diagnostics.py
@@ -96,7 +96,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         property : str
             Unit of energy. Should be one of
 
-            - 'energy' returns energy in eV
+            - 'energy' returns energy in MeV
             - 'gamma' returns Lorentz factor
 
         Returns


### PR DESCRIPTION
seems `get_energy_spread` returns energy in MeV despite the doc-string