### PR TITLE
Fix: Numpy 1.16+ for LPA Diag

### DIFF
--- a/openpmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/openpmd_viewer/addons/pic/lpa_diagnostics.py
@@ -923,7 +923,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         # Find the indices of the maximum field, and
         # pick the corresponding transverse slice
         itrans_max, iz_max = np.unravel_index(
-            np.argmax( field ), dims=field.shape )
+            np.argmax( field ), field.shape )
         trans_slice = field[ :, iz_max ]
         # Get transverse positons
         trans_pos = getattr(info, info.axes[0])


### PR DESCRIPTION
The `np.unravel_index` `dims` parameter is called `shape` in 1.16.0+.
  https://numpy.org/doc/stable/reference/generated/numpy.unravel_index.html

Rewrite in a compatible way for both earlier and later numpy releases.

Fixes:
```
----> 1 waist = ts_Diags.get_laser_waist(iteration=3000, pol='y')

~/.conda/envs/warpx/lib/python3.8/site-packages/openpmd_viewer/addons/pic/lpa_diagnostics.py in get_laser_waist(self, t, iteration, pol, theta, method)
    839         # Find the indices of the maximum field, and
    840         # pick the corresponding transverse slice
--> 841         itrans_max, iz_max = np.unravel_index(
    842             np.argmax( field ), dims=field.shape )
    843         trans_slice = field[ :, iz_max ]

<__array_function__ internals> in unravel_index(*args, **kwargs)

TypeError: unravel_index() got an unexpected keyword argument 'dims'
```

First seen by @camille12225 :+1: 