### PR TITLE
Fix the link to online tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ the API and the interactive GUI. You can view these notebooks online
 [here](https://github.com/openPMD/openPMD-viewer/tree/main/tutorials).
 
 Alternatively, you can even
-[*run* our tutorials online](https://mybinder.org/v2/gh/openPMD/openPMD-viewer/main?filepath=tutorials%2F)!
+[*run* our tutorials online](https://mybinder.org/v2/gh/openPMD/openPMD-viewer/master?filepath=tutorials%2F)!
 
 You can also download and run these notebooks on your local computer
 (when viewing the notebooks with the above link, click on `Raw` to be able to

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ visualize the data.
 
 The notebooks in the folder `tutorials/` demonstrate how to use both
 the API and the interactive GUI. You can view these notebooks online
-[here](https://github.com/openPMD/openPMD-viewer/tree/main/tutorials).
+[here](https://github.com/openPMD/openPMD-viewer/tree/master/tutorials).
 
 Alternatively, you can even
 [*run* our tutorials online](https://mybinder.org/v2/gh/openPMD/openPMD-viewer/master?filepath=tutorials%2F)!


### PR DESCRIPTION
This changes the branch name in the `mybinder` link to master so that the link works again.