### PR TITLE
setup.py: ipympl for Jupyter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,9 @@ setup(name='openPMD-viewer',
       tests_require=['pytest', 'jupyter'],
       install_requires=install_requires,
       extras_require = {
-        'GUI':  ["ipywidgets", "matplotlib"],
+        'GUI':  ["ipywidgets", "ipympl", "matplotlib"],
         'plot': ["matplotlib"],
-        'tutorials': ["ipywidgets", "matplotlib", "wget"],
+        'tutorials': ["ipywidgets", "ipympl", "matplotlib", "wget"],
         'openpmd-api': ["openpmd-api"]
         },
       cmdclass={'test': PyTest},


### PR DESCRIPTION
For an interactive, modern Jupyter lab/notebook setup, we should depend on [ipympl](https://github.com/matplotlib/ipympl) for `%matplotlib widget`.