### PR TITLE
setup.py: "numba" and "all" extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,11 @@ setup(name='openPMD-viewer',
       tests_require=['pytest', 'jupyter'],
       install_requires=install_requires,
       extras_require = {
+        'all': ["ipympl", "ipywidgets", "matplotlib", "numba", "openpmd-api", "wget"],
         'GUI':  ["ipywidgets", "ipympl", "matplotlib"],
         'plot': ["matplotlib"],
         'tutorials': ["ipywidgets", "ipympl", "matplotlib", "wget"],
+        'numba': ["numba"],
         'openpmd-api': ["openpmd-api"]
         },
       cmdclass={'test': PyTest},


### PR DESCRIPTION
Add two options to `setup.py`:
- "numba" (for faster particle histograms)
- "all" (providing all extra dependencies)

Todo:
- [x] rebase after #326 was merged