### PR TITLE
h5py: improve hints for `.bp` & other files

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/data_reader/data_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/data_reader.py
@@ -81,7 +81,9 @@ class DataReader( object ):
                 raise RuntimeError(
                     "Found no valid files in directory {0}.\n"
                     "Please check that this is the path to the openPMD files."
-                    "(valid files must have the extension '.h5')"
+                    "Valid files must have the extension '.h5' if you "
+                    "use the `h5py` backend. For ADIOS '.bp' and other files, "
+                    "please install the `openpmd-api` package."
                     .format(path_to_dir))
         elif self.backend == 'openpmd-api':
             # guess file ending from first file in directory


### PR DESCRIPTION
Improve the hint when a user tries to open `.bp` files but only has `h5py` installed.