### PR TITLE
Raise an exception if the user passes an iteration that is not available

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/main.py
+++ b/openpmd_viewer/openpmd_timeseries/main.py
@@ -626,10 +626,9 @@ class OpenPMDTimeSeries(InteractiveViewer):
                 self._current_i = abs(iteration - self.iterations).argmin()
             else:
                 iter_list = '\n - '.join([str(it) for it in self.iterations])
-                print("The requested iteration '%s' is not available.\nThe "
-                      "available iterations are: \n - %s\nThe first iteration "
-                      "is used instead." % (iteration, iter_list))
-                self._current_i = 0
+                raise OpenPMDException(
+                      "The requested iteration '%s' is not available.\nThe "
+                      "available iterations are: \n - %s\n" % (iteration, iter_list))
         else:
             pass  # self._current_i retains its previous value
 


### PR DESCRIPTION
Previously, `openPMD-viewer` simply printed a message, and resorted to using the first iteration instead. However, this is easy for the user to miss, and could cause confusion.