### PR TITLE
Fix bug in when reconstructing a 3D field from `thetaMode` data

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/field_reader.py
@@ -239,6 +239,11 @@ def read_field_circ( filename, iteration, field, coord,
                 info.r = info.r[::excess_r]
                 info.dr = info.r[1] - info.r[0]
                 inv_dr = 1./info.dr
+                # Update Nr after reducing radial resolution.
+                if not rz_switch:
+                    Nr = Fcirc.shape[1]
+                else:
+                    Nr = Fcirc.shape[2]
 
         # Convert cylindrical data to Cartesian data
         info._convert_cylindrical_to_3Dcartesian()

--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/field_reader.py
@@ -244,6 +244,11 @@ def read_field_circ( series, iteration, field_name, component_name,
                 info.r = info.r[::excess_r]
                 info.dr = info.r[1] - info.r[0]
                 inv_dr = 1./info.dr
+                # Update Nr after reducing radial resolution.
+                if not rz_switch:
+                    Nr = Fcirc.shape[1]
+                else:
+                    Nr = Fcirc.shape[2]
 
         # Convert cylindrical data to Cartesian data
         info._convert_cylindrical_to_3Dcartesian()


### PR DESCRIPTION
In #337, a bug was introduced that causes the 3D reconstruction to fail if  `Nr > max_res_transv/2`. This is because `Nr` is no longer being updated after reducing the radial resolution of the `Fcirc` array. This PR adds back the lines of code that were updating this value.