### PR TITLE
Support groupBased Encoding (Single File Reads)

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/data_reader/data_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/data_reader.py
@@ -94,7 +94,7 @@ class DataReader( object ):
             if first_file_name is None:
                 raise RuntimeError(
                     "Found no valid files in directory {0}.\n"
-                    "Please check that this is the path to the openPMD files."
+                    "Please check that this is the path to the openPMD files.\n"
                     "(valid files must have one of the following extensions: {1})"
                     .format(path_to_dir, io.file_extensions))
 

--- a/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/utilities.py
@@ -29,8 +29,14 @@ def list_files(path_to_dir):
     - an array of integers which correspond to the iteration of each file
     - a dictionary that matches iterations to the corresponding filename
     """
-    # Find all the files in the provided directory
-    all_files = os.listdir(path_to_dir)
+    # group based encoding?
+    is_single_file = os.path.isfile(path_to_dir)
+
+    if is_single_file:
+        all_files = [path_to_dir]
+    else:
+        # Find all the files in the provided directory
+        all_files = os.listdir(path_to_dir)
 
     # Select the hdf5 files, and fill dictionary of correspondence
     # between iterations and files
@@ -38,8 +44,11 @@ def list_files(path_to_dir):
     for filename in all_files:
         # Use only the name that end with .h5 or .hdf5
         if filename.endswith('.h5') or filename.endswith('.hdf5'):
-            full_name = os.path.join(
-                os.path.abspath(path_to_dir), filename)
+            if is_single_file:
+                full_name = filename
+            else:
+                full_name = os.path.join(
+                    os.path.abspath(path_to_dir), filename)
             # extract all iterations from hdf5 file
             f = h5py.File(full_name, 'r')
             iterations = list(f['/data'].keys())


### PR DESCRIPTION
Support reading a single file that uses group-based iteration encoding.

This is useful for things like scan numbers in file names used for CCD images: https://github.com/openPMD/openPMD-CCD#usage-read