### PR TITLE
When passing `t`, choose the closest iteration

### DIFF
--- a/openpmd_viewer/addons/pic/lpa_diagnostics.py
+++ b/openpmd_viewer/addons/pic/lpa_diagnostics.py
@@ -63,7 +63,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         ----------
         t : float (in seconds), optional
             Time at which to obtain the data (if this does not correspond to
-            an available file, the last file before `t` will be used)
+            an existing iteration, the closest existing iteration will be used)
             Either `t` or `iteration` should be given by the user.
 
         iteration : int
@@ -147,7 +147,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         ----------
         t : float (in seconds), optional
             Time at which to obtain the data (if this does not correspond to
-            an available file, the last file before `t` will be used)
+            an existing iteration, the closest existing iteration will be used)
             Either `t` or `iteration` should be given by the user.
 
         iteration : int
@@ -200,7 +200,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
 
         t : float (in seconds), optional
             Time at which to obtain the data (if this does not correspond to
-            an available file, the last file before `t` will be used)
+            an existing iteration, the closest existing iteration will be used)
             Either `t` or `iteration` should be given by the user.
 
         iteration : int
@@ -268,7 +268,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         ----------
         t : float (in seconds), optional
             Time at which to obtain the data (if this does not correspond to
-            an available file, the last file before `t` will be used)
+            an existing iteration, the closest existing iteration will be used)
             Either `t` or `iteration` should be given by the user.
 
         iteration : int
@@ -305,7 +305,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         ----------
         t : float (in seconds), optional
             Time at which to obtain the data (if this does not correspond to
-            an available file, the last file before `t` will be used)
+            an existing iteration, the closest existing iteration will be used)
             Either `t` or `iteration` should be given by the user.
 
         iteration : int
@@ -348,7 +348,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         ----------
         t : float (in seconds), optional
             Time at which to obtain the data (if this does not correspond to
-            an available file, the last file before `t` will be used)
+            an existing iteration, the closest existing iteration will be used)
             Either `t` or `iteration` should be given by the user.
 
         iteration : int
@@ -462,7 +462,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         ----------
          t : float (in seconds), optional
             Time at which to obtain the data (if this does not correspond to
-            an available file, the last file before `t` will be used)
+            an existing iteration, the closest existing iteration will be used)
             Either `t` or `iteration` should be given by the user
 
         iteration : int
@@ -547,7 +547,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         ----------
         t : float (in seconds), optional
             Time at which to obtain the data (if this does not correspond to
-            an available file, the last file before `t` will be used)
+            an existing iteration, the closest existing iteration will be used)
             Either `t` or `iteration` should be given by the user.
 
         iteration : int
@@ -671,7 +671,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         ----------
         t : float (in seconds), optional
             Time at which to obtain the data (if this does not correspond to
-            an available file, the last file before `t` will be used)
+            an existing iteration, the closest existing iteration will be used)
             Either `t` or `iteration` should be given by the user.
 
         iteration : int
@@ -726,7 +726,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         ----------
         t : float (in seconds), optional
             Time at which to obtain the data (if this does not correspond to
-            an available file, the last file before `t` will be used)
+            an existing iteration, the closest existing iteration will be used)
             Either `t` or `iteration` should be given by the user.
 
         iteration : int
@@ -794,7 +794,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         ----------
         t : float (in seconds), optional
             Time at which to obtain the data (if this does not correspond to
-            an available file, the last file before `t` will be used)
+            an existing iteration, the closest existing iteration will be used)
             Either `t` or `iteration` should be given by the user.
 
         iteration : int
@@ -829,7 +829,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         ----------
         t : float (in seconds), optional
             Time at which to obtain the data (if this does not correspond to
-            an available file, the last file before `t` will be used)
+            an existing iteration, the closest existing iteration will be used)
             Either `t` or `iteration` should be given by the user.
 
         iteration : int
@@ -885,7 +885,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         ----------
         t : float (in seconds), optional
             Time at which to obtain the data (if this does not correspond to
-            an available file, the last file before `t` will be used)
+            an existing iteration, the closest existing iteration will be used)
             Either `t` or `iteration` should be given by the user.
 
         iteration : int
@@ -965,7 +965,7 @@ class LpaDiagnostics( OpenPMDTimeSeries ):
         ----------
         t : float (in seconds), optional
             Time at which to obtain the data (if this does not correspond to
-            an available file, the last file before `t` will be used)
+            an existing iteration, the closest existing iteration will be used)
             Either `t` or `iteration` should be given by the user.
 
         iteration : int

--- a/openpmd_viewer/openpmd_timeseries/main.py
+++ b/openpmd_viewer/openpmd_timeseries/main.py
@@ -149,7 +149,7 @@ class OpenPMDTimeSeries(InteractiveViewer):
 
         t : float (in seconds), optional
             Time at which to obtain the data (if this does not correspond to
-            an available iteration, the last iteration before `t` will be used)
+            an existing iteration, the closest existing iteration will be used)
             Either `t` or `iteration` should be given by the user.
 
         iteration : int
@@ -383,7 +383,7 @@ class OpenPMDTimeSeries(InteractiveViewer):
 
         t : float (in seconds), optional
             Time at which to obtain the data (if this does not correspond to
-            an available file, the last file before `t` will be used)
+            an existing iteration, the closest existing iteration will be used)
             Either `t` or `iteration` should be given by the user.
 
         iteration : int
@@ -611,12 +611,12 @@ class OpenPMDTimeSeries(InteractiveViewer):
                 "iteration (`iteration`), but not both.")
         # If a time is requested
         elif (t is not None):
-            # Make sur the time requested does not exceed the allowed bounds
+            # Make sure the time requested does not exceed the allowed bounds
             if t < self.tmin:
                 self._current_i = 0
             elif t > self.tmax:
                 self._current_i = len(self.t) - 1
-            # Find the last existing output
+            # Find the closest existing iteration
             else:
                 self._current_i = abs(self.t - t).argmin()
         # If an iteration is requested

--- a/openpmd_viewer/openpmd_timeseries/main.py
+++ b/openpmd_viewer/openpmd_timeseries/main.py
@@ -618,7 +618,7 @@ class OpenPMDTimeSeries(InteractiveViewer):
                 self._current_i = len(self.t) - 1
             # Find the last existing output
             else:
-                self._current_i = self.t[self.t <= t].argmax()
+                self._current_i = abs(self.t - t).argmin()
         # If an iteration is requested
         elif (iteration is not None):
             if (iteration in self.iterations):

--- a/openpmd_viewer/openpmd_timeseries/particle_tracker.py
+++ b/openpmd_viewer/openpmd_timeseries/particle_tracker.py
@@ -56,7 +56,7 @@ class ParticleTracker( object ):
 
         t : float (in seconds), optional
             Time at which to obtain the data (if this does not correspond to
-            an available file, the last file before `t` will be used)
+            an existing iteration, the closest existing iteration will be used)
             Either `t` or `iteration` should be given by the user.
 
         iteration : int


### PR DESCRIPTION
When the user passes `t` in `get_particle` or `get_field`, `openPMD-viewer` used to choose the **last iteration before `t`**.

However, this is usually not what the user desires. Instead, `openPMD-viewer` should choose the iteration whose time is **closest to t**.

This PR fixes this problem.