### PR TITLE
Allow openPMD-viewer to extract and plot complex numbers

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/utilities.py
@@ -84,7 +84,7 @@ def is_scalar_record(record):
     return(scalar)
 
 
-def get_data(dset, i_slice=None, pos_slice=None, output_type=np.float64):
+def get_data(dset, i_slice=None, pos_slice=None, output_type=None):
     """
     Extract the data from a (possibly constant) dataset
     Slice the data according to the parameters i_slice and pos_slice
@@ -145,10 +145,11 @@ def get_data(dset, i_slice=None, pos_slice=None, output_type=np.float64):
             data = dset[tuple_index]
 
     # Convert to the right type
-    if data.dtype != output_type:
+    if (output_type is not None) and (data.dtype != output_type):
         data = data.astype( output_type )
     # Scale by the conversion factor
-    if output_type in [ np.float64, np.float32, np.float16 ]:
+    if data.dtype in [ np.float128, np.float64, np.float32, np.float16,
+                        np.complex256, np.complex128, np.complex64 ]:
         if dset.attrs['unitSI'] != 1.0:
             data *= dset.attrs['unitSI']
 

--- a/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/utilities.py
@@ -148,8 +148,8 @@ def get_data(dset, i_slice=None, pos_slice=None, output_type=None):
     if (output_type is not None) and (data.dtype != output_type):
         data = data.astype( output_type )
     # Scale by the conversion factor
-    if data.dtype in [ np.float128, np.float64, np.float32, np.float16,
-                        np.complex256, np.complex128, np.complex64 ]:
+    if np.isinstance(data.dtype, np.floating) or \
+        np.isinstance(data.dtype, np.complexfloating):
         if dset.attrs['unitSI'] != 1.0:
             data *= dset.attrs['unitSI']
 

--- a/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/utilities.py
@@ -148,8 +148,8 @@ def get_data(dset, i_slice=None, pos_slice=None, output_type=None):
     if (output_type is not None) and (data.dtype != output_type):
         data = data.astype( output_type )
     # Scale by the conversion factor
-    if np.isinstance(data.dtype, np.floating) or \
-        np.isinstance(data.dtype, np.complexfloating):
+    if np.issubdtype(data.dtype, np.floating) or \
+        np.issubdtype(data.dtype, np.complexfloating):
         if dset.attrs['unitSI'] != 1.0:
             data *= dset.attrs['unitSI']
 

--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/utilities.py
@@ -22,7 +22,7 @@ def chunk_to_slice(chunk):
 
 
 def get_data(series, record_component, i_slice=None, pos_slice=None,
-             output_type=np.float64):
+             output_type=None):
     """
     Extract the data from a (possibly constant) dataset
     Slice the data according to the parameters i_slice and pos_slice
@@ -81,7 +81,7 @@ def get_data(series, record_component, i_slice=None, pos_slice=None,
             del slice_shape[dir_index]
 
         # mask invalid regions with NaN
-        data = np.full(slice_shape, np.nan, dtype=output_type)
+        data = np.full(slice_shape, np.nan, dtype=record_component.dtype)
 
         # build requested ND slice with respect to full data
         s = []
@@ -125,10 +125,11 @@ def get_data(series, record_component, i_slice=None, pos_slice=None,
                 data[s_target] = x
 
     # Convert to the right type
-    if data.dtype != output_type:
+    if (output_type is not None) and (data.dtype != output_type):
         data = data.astype( output_type )
     # Scale by the conversion factor
-    if output_type in [ np.float64, np.float32, np.float16 ]:
+    if data.dtype in [ np.float128, np.float64, np.float32, np.float16,
+                        np.complex256, np.complex128, np.complex64 ]:
         if record_component.unit_SI != 1.0:
             data *= record_component.unit_SI
 

--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/utilities.py
@@ -128,8 +128,8 @@ def get_data(series, record_component, i_slice=None, pos_slice=None,
     if (output_type is not None) and (data.dtype != output_type):
         data = data.astype( output_type )
     # Scale by the conversion factor
-    if data.dtype in [ np.float128, np.float64, np.float32, np.float16,
-                        np.complex256, np.complex128, np.complex64 ]:
+    if np.issubdtype(data.dtype, np.floating) or \
+        np.issubdtype(data.dtype, np.complexfloating):
         if record_component.unit_SI != 1.0:
             data *= record_component.unit_SI
 

--- a/openpmd_viewer/openpmd_timeseries/plotter.py
+++ b/openpmd_viewer/openpmd_timeseries/plotter.py
@@ -294,19 +294,22 @@ class Plotter(object):
         iteration = self.iterations[current_i]
         time = self.t[current_i]
 
-        # Get the title and labels
-        plt.title("%s at %.2e s   (iteration %d)" % (field_label,
-                    time, iteration), fontsize=self.fontsize)
-
-        # Add the name of the axes
-        plt.xlabel('$%s \;(m)$' % info.axes[0], fontsize=self.fontsize)
         # Get the x axis
         xaxis = getattr( info, info.axes[0] )
         # Plot the data
         if F.dtype in [np.complex256, np.complex128, np.complex64]:
             plot_data = abs(F) # For complex numbers, plot the absolute value
+            title = "|%s|" %field_label
         else:
             plot_data = F
+            title = "%s" %field_label
+
+        # Get the title and labels
+        title += " at %.2e s   (iteration %d)" % (time, iteration)
+        plt.title(title, fontsize=self.fontsize)
+        # Add the name of the axes
+        plt.xlabel('$%s \;(m)$' % info.axes[0], fontsize=self.fontsize)
+
         plt.plot( xaxis, plot_data )
         # Get the limits of the plot
         # - Along the first dimension
@@ -360,31 +363,31 @@ class Plotter(object):
         iteration = self.iterations[current_i]
         time = self.t[current_i]
 
+        # Plot the data
+        if F.dtype in [np.complex256, np.complex128, np.complex64]:
+            plot_data = abs(F)
+            title = "|%s|" %field_label
+        else:
+            plot_data = F
+            title = "%s" %field_label
+        plt.imshow(plot_data, extent=info.imshow_extent, origin='lower',
+                   interpolation='nearest', aspect='auto', **kw)
+        plt.colorbar()
+
         # Get the title and labels
         # Cylindrical geometry
         if geometry == "thetaMode":
             mode = str(m)
-            plt.title("%s in the mode %s at %.2e s   (iteration %d)"
-                      % (field_label, mode, time, iteration),
-                      fontsize=self.fontsize)
+            title += " in the mode %s at %.2e s   (iteration %d)" \
+                      % (mode, time, iteration)
         # 2D Cartesian geometry
         else:
-            plt.title("%s at %.2e s   (iteration %d)"
-                      % (field_label, time, iteration),
-                      fontsize=self.fontsize)
+            title += " at %.2e s   (iteration %d)" % (time, iteration)
+        plt.title(title, fontsize=self.fontsize)
 
         # Add the name of the axes
         plt.xlabel('$%s \;(m)$' % info.axes[1], fontsize=self.fontsize)
         plt.ylabel('$%s \;(m)$' % info.axes[0], fontsize=self.fontsize)
-
-        # Plot the data
-        if F.dtype in [np.complex256, np.complex128, np.complex64]:
-            plot_data = abs(F)
-        else:
-            plot_data = F
-        plt.imshow(plot_data, extent=info.imshow_extent, origin='lower',
-                   interpolation='nearest', aspect='auto', **kw)
-        plt.colorbar()
 
         # Get the limits of the plot
         # - Along the first dimension

--- a/openpmd_viewer/openpmd_timeseries/plotter.py
+++ b/openpmd_viewer/openpmd_timeseries/plotter.py
@@ -303,7 +303,11 @@ class Plotter(object):
         # Get the x axis
         xaxis = getattr( info, info.axes[0] )
         # Plot the data
-        plt.plot( xaxis, F )
+        if F.dtype in [np.complex256, np.complex128, np.complex64]:
+            plot_data = abs(F) # For complex numbers, plot the absolute value
+        else:
+            plot_data = F
+        plt.plot( xaxis, plot_data )
         # Get the limits of the plot
         # - Along the first dimension
         if (plot_range[0][0] is not None) and (plot_range[0][1] is not None):
@@ -374,7 +378,11 @@ class Plotter(object):
         plt.ylabel('$%s \;(m)$' % info.axes[0], fontsize=self.fontsize)
 
         # Plot the data
-        plt.imshow(F, extent=info.imshow_extent, origin='lower',
+        if F.dtype in [np.complex256, np.complex128, np.complex64]:
+            plot_data = abs(F)
+        else:
+            plot_data = F
+        plt.imshow(plot_data, extent=info.imshow_extent, origin='lower',
                    interpolation='nearest', aspect='auto', **kw)
         plt.colorbar()
 

--- a/openpmd_viewer/openpmd_timeseries/plotter.py
+++ b/openpmd_viewer/openpmd_timeseries/plotter.py
@@ -297,7 +297,7 @@ class Plotter(object):
         # Get the x axis
         xaxis = getattr( info, info.axes[0] )
         # Plot the data
-        if F.dtype in [np.complex256, np.complex128, np.complex64]:
+        if np.issubdtype(F.dtype, np.complexfloating):
             plot_data = abs(F) # For complex numbers, plot the absolute value
             title = "|%s|" %field_label
         else:
@@ -364,7 +364,7 @@ class Plotter(object):
         time = self.t[current_i]
 
         # Plot the data
-        if F.dtype in [np.complex256, np.complex128, np.complex64]:
+        if np.issubdtype(F.dtype, np.complexfloating):
             plot_data = abs(F)
             title = "|%s|" %field_label
         else:


### PR DESCRIPTION
Before this PR, `openPMD-viewer` was casting complex datasets to reals, and therefore discarding the imaginary part. 

Similarly, using `plt.plot` or `plt.imshow` with a complex array raises a warning, saying that the imaginary part was discarded. Here we choose to plot the modulus of the complex numbers instead.

This will be useful in order to plot the laser envelope, which is complex by nature.