### PR TITLE
ADIOS2: Support NULL-Blocks (Chunks)

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/utilities.py
@@ -66,6 +66,15 @@ def get_data(series, record_component, i_slice=None, pos_slice=None,
         data = np.full(record_component.shape, np.nan, record_component.dtype)
         for chunk in chunks:
             chunk_slice = chunk_to_slice(chunk)
+
+            # skip empty slices
+            # https://github.com/ornladios/ADIOS2
+            volume = 1
+            for csl in chunk_slice:
+                volume *= csl.stop - csl.start
+            if volume == 0:
+                continue
+
             # read only valid region
             x = record_component[chunk_slice]
             series.flush()
@@ -98,6 +107,15 @@ def get_data(series, record_component, i_slice=None, pos_slice=None,
             s_valid = list(s)  # same as s but reduced to valid regions in chunk
             s_target = []  # starts and stops in sliced array
             chunk_slice = chunk_to_slice(chunk)
+
+            # skip empty slices
+            # https://github.com/ornladios/ADIOS2
+            volume = 1
+            for csl in chunk_slice:
+                volume *= csl.stop - csl.start
+            if volume == 0:
+                continue
+
             # read only valid region
             for d, slice_d in enumerate(s):
                 start = chunk_slice[d].start


### PR DESCRIPTION
Add support to read back ADIOS2 data sets that contain empty blocks (NULL chunks). This is something to handle carefully and needed for a work-arounds in WarpX BTD.

X-Refs.:
- https://github.com/ornladios/ADIOS2/issues/3459
- https://github.com/ECP-WarpX/WarpX/pull/3657