### PR TITLE
Add readthedoc configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: "3.11"
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,23 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+    configuration: doc/source/conf.py
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+    install:
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-    configuration: doc/source/conf.py
+    configuration: docs/source/conf.py
 
 # Optional but recommended, declare the Python requirements required
 # to build your documentation

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,6 +5,7 @@ nbsphinx
 wget
 numba
 numpy
+matplotlib
 scipy
 h5py
 tqdm

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,8 @@
+sphinx
+sphinx_rtd_theme
+wget
+numba
+numpy
+scipy
+h5py
+tqdm

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 sphinx
+sphinx-design
 sphinx_rtd_theme
 jupyter
 nbsphinx
@@ -6,6 +7,7 @@ wget
 numba
 numpy
 matplotlib
+pygments
 scipy
 h5py
 tqdm

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx
 sphinx_rtd_theme
+jupyter
 wget
 numba
 numpy

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx
 sphinx_rtd_theme
+nbsphinx
 wget
 numba
 numpy

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,3 +6,4 @@ numpy
 scipy
 h5py
 tqdm
+openpmd_viewer

--- a/docs/source/api_reference/particle_tracking.rst
+++ b/docs/source/api_reference/particle_tracking.rst
@@ -2,5 +2,3 @@ Particle tracking: ``ParticleTracker``
 -------------------------------------
 
 .. autoclass:: openpmd_viewer.ParticleTracker
-
-    .. automethod::

--- a/docs/source/api_reference/particle_tracking.rst
+++ b/docs/source/api_reference/particle_tracking.rst
@@ -1,4 +1,4 @@
 Particle tracking: ``ParticleTracker``
--------------------------------------
+--------------------------------------
 
 .. autoclass:: openpmd_viewer.ParticleTracker


### PR DESCRIPTION
This adds the openPMD-viewer documentation in readthedocs:
[openpmd-viewer.readthedocs.io/](https://openpmd-viewer.readthedocs.io/)
(Right now ReadtheDoc builds from the `doc` branch ; but once this PR is merged, I will change this to `dev`.)