### PR TITLE
setup.py: no upper version of openPMD-api

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,12 +38,12 @@ setup(name='openPMD-viewer',
       tests_require=['pytest', 'jupyter'],
       install_requires=install_requires,
       extras_require = {
-        'all': ["ipympl", "ipywidgets", "matplotlib", "numba", "openpmd-api~=0.14.0", "wget"],
+        'all': ["ipympl", "ipywidgets", "matplotlib", "numba", "openpmd-api", "wget"],
         'GUI':  ["ipywidgets", "ipympl", "matplotlib"],
         'plot': ["matplotlib"],
         'tutorials': ["ipywidgets", "ipympl", "matplotlib", "wget"],
         'numba': ["numba"],
-        'openpmd-api': ["openpmd-api~=0.14.0"]
+        'openpmd-api': ["openpmd-api"]
         },
       cmdclass={'test': PyTest},
       platforms='any',


### PR DESCRIPTION
We break very seldomly and found this can confuse pip in complex scenarios.

Also, upper limits are considered bad practice, so we make it simpler now.