### PR TITLE
Do not use pyflakes for version 3.7

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -38,12 +38,15 @@ jobs:
         if [ "${{ matrix.python-version }}" != "3.8" ]; then
           conda install --yes cython numpy scipy h5py openpmd-api matplotlib jupyter pytest pyflakes python=${{ matrix.python-version }} python-wget
         else
-          conda install --yes cython numpy scipy h5py matplotlib jupyter pytest pyflakes python=${{ matrix.python-version }} python-wget 
+          conda install --yes cython numpy scipy h5py matplotlib jupyter pytest pyflakes python=${{ matrix.python-version }} python-wget
         fi
 
     - shell: bash -eo pipefail  -l {0}
       name: pyflakes
-      run: python -m pyflakes openpmd_viewer
+      run: |
+        if [ "${{ matrix.python-version }}" != "3.7" ]; then
+          python -m pyflakes openpmd_viewer
+        fi
     - shell: bash -eo pipefail -l {0}
       name: Test
       run: python setup.py test


### PR DESCRIPTION
It seems that `pyflakes` dropped support for Python 3.7:
https://github.com/PyCQA/pyflakes/pull/752/files
and in practice, trying to use `pyflakes` with Python 3.7 indeed raises errors.

Therefore, this PR removes the `pyflakes` test for this version of Python.