### PR TITLE
Enable support for heterogeneous data and expose `max_resolution_3d`

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/main.py
+++ b/openpmd_viewer/openpmd_timeseries/main.py
@@ -362,8 +362,8 @@ class OpenPMDTimeSeries(InteractiveViewer):
 
     def get_field(self, field=None, coord=None, t=None, iteration=None,
                   m='all', theta=0., slice_across=None,
-                  slice_relative_position=None, plot=False,
-                  plot_range=[[None, None], [None, None]], **kw):
+                  slice_relative_position=None, max_resolution_3d=None,
+                  plot=False, plot_range=[[None, None], [None, None]], **kw):
         """
         Extract a given field from a file in the openPMD format.
 
@@ -415,6 +415,13 @@ class OpenPMDTimeSeries(InteractiveViewer):
            1 : upper edge of the simulation box
            Default: None, which results in slicing at 0 in all direction
            of `slice_across`.
+
+        max_resolution_3d : list of int or None
+            Maximum resolution that the 3D reconstruction of the field (when
+            `theta` is None) can have. The list should contain two values,
+            e.g. `[200, 100]`, indicating the maximum longitudinal and
+            transverse resolution, respectively. This is useful for
+            performance reasons, particularly for 3D visualization.
 
         plot : bool, optional
            Whether to plot the requested quantity
@@ -510,16 +517,16 @@ class OpenPMDTimeSeries(InteractiveViewer):
                 # For Cartesian components, combine r and t components
                 Fr, info = self.data_reader.read_field_circ(
                     iteration, field, 'r', slice_relative_position,
-                    slice_across, m, theta)
+                    slice_across, m, theta, max_resolution_3d)
                 Ft, info = self.data_reader.read_field_circ(
                     iteration, field, 't', slice_relative_position,
-                    slice_across, m, theta)
+                    slice_across, m, theta, max_resolution_3d)
                 F = combine_cylindrical_components(Fr, Ft, theta, coord, info)
             else:
                 # For cylindrical or scalar components, no special treatment
                 F, info = self.data_reader.read_field_circ(iteration,
                     field, coord, slice_relative_position,
-                    slice_across, m, theta)
+                    slice_across, m, theta, max_resolution_3d)
 
         # Plot the resulting field
         # Deactivate plotting when there is no slice selection

--- a/openpmd_viewer/openpmd_timeseries/main.py
+++ b/openpmd_viewer/openpmd_timeseries/main.py
@@ -80,7 +80,7 @@ class OpenPMDTimeSeries(InteractiveViewer):
 
         # Go through the files of the series, extract the time
         # and a few parameters.
-        self.determine_available_data()
+        self.determine_available_data(check_all_files)
 
         # - Set the current iteration and time
         self._current_i = 0

--- a/openpmd_viewer/openpmd_timeseries/main.py
+++ b/openpmd_viewer/openpmd_timeseries/main.py
@@ -169,7 +169,6 @@ class OpenPMDTimeSeries(InteractiveViewer):
                 self.species_t[sp] = self.t
                 self.species_iterations[sp] = self.iterations
         
-
         # For backwards compatibility
         if not self.avail_fields:
             self.avail_fields = None

--- a/openpmd_viewer/openpmd_timeseries/main.py
+++ b/openpmd_viewer/openpmd_timeseries/main.py
@@ -117,7 +117,7 @@ class OpenPMDTimeSeries(InteractiveViewer):
         for i, it in enumerate(self.iterations):
             check_file = (i == 0) or check_all_files
             t, params = self.data_reader.read_openPMD_params(it, check_file)
-            self.t[it] = t
+            self.t[i] = t
             if check_file:
                 avail_fields_it = params['avail_fields']
                 avail_species_it = params['avail_species']


### PR DESCRIPTION
Hi all,

I'm in the process of making the VisualPIC backend fully rely on the `OpenPMDTimeSeries` (https://github.com/AngelFP/VisualPIC/pull/57). This will make it  easier to maintain and avoid code duplication. In order to do this, this PR ports a couple of features from VisualPIC to the viewer:
- Enabling support for heterogeneous data, meaning `openPMD` series where each iteration can have different fields and species than the others. Until now, the `OpenPMDTimeSeries` would simply raise a warning.
- Update the `slider` to support the case above.
- Expose the `max_resolution_3d` parameter in the `get_field` method (until now it was only available in the `DataReader`).