### PR TITLE
Support complex data in `thetaMode` geometry

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/field_reader.py
@@ -277,7 +277,7 @@ def read_field_circ( filename, iteration, field, coord,
         # Convert cylindrical data to Cartesian data
         info._convert_cylindrical_to_3Dcartesian()
         nx, ny, nz = len(info.x), len(info.y), len(info.z)
-        F_total = np.zeros( (nx, ny, nz) )
+        F_total = np.zeros( (nx, ny, nz), dtype=dset.dtype )
         construct_3d_from_circ( F_total, Fcirc, info.x, info.y, modes,
             nx, ny, nz, Nr, nmodes, inv_dr, rmax, coord_order )
 
@@ -285,9 +285,9 @@ def read_field_circ( filename, iteration, field, coord,
 
         # Extract the modes and recombine them properly
         if coord_order is RZorder.mrz:
-            F_total = np.zeros( (2 * Nr, Nz ) )
+            F_total = np.zeros( (2 * Nr, Nz ), dtype=dset.dtype )
         elif coord_order is RZorder.mzr:
-            F_total = np.zeros( (Nz, 2 * Nr ) )
+            F_total = np.zeros( (Nz, 2 * Nr ), dtype=dset.dtype )
         else:
             raise Exception(order_error_msg)
         if m == 'all':

--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/field_reader.py
@@ -268,7 +268,7 @@ def read_field_circ( series, iteration, field_name, component_name,
         # Convert cylindrical data to Cartesian data
         info._convert_cylindrical_to_3Dcartesian()
         nx, ny, nz = len(info.x), len(info.y), len(info.z)
-        F_total = np.zeros( (nx, ny, nz) )
+        F_total = np.zeros( (nx, ny, nz), dtype=component.dtype )
         construct_3d_from_circ( F_total, Fcirc, info.x, info.y, modes,
             nx, ny, nz, Nr, nmodes, inv_dr, rmax, coord_order)
 
@@ -276,9 +276,9 @@ def read_field_circ( series, iteration, field_name, component_name,
 
         # Extract the modes and recombine them properly
         if coord_order is RZorder.mrz:
-            F_total = np.zeros( (2 * Nr, Nz ) )
+            F_total = np.zeros( (2 * Nr, Nz ), dtype=component.dtype )
         elif coord_order is RZorder.mzr:
-            F_total = np.zeros( (Nz, 2 * Nr ) )
+            F_total = np.zeros( (Nz, 2 * Nr ), dtype=component.dtype )
         else:
             raise Exception(order_error_msg)
         if m == 'all':


### PR DESCRIPTION
This PR fixes a bug where the viewer would fail to read complex field arrays in `thetaMode` geometry.