### PR TITLE
Add all record attributes to `FieldMetaInformation`

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/field_reader.py
@@ -113,14 +113,16 @@ def read_field_cartesian( filename, iteration, field, coord, axis_labels,
         F = get_data( dset, list_i_cell, list_slicing_index )
         info = FieldMetaInformation( axes, shape, grid_spacing, global_offset,
                 group.attrs['gridUnitSI'], dset.attrs['position'],
-                time, iteration )
+                time, iteration, component_attrs=dict(dset.attrs),
+                field_attrs=dict(group.attrs) )
     else:
         F = get_data( dset )
         axes = { i: axis_labels[i] for i in range(len(axis_labels)) }
         info = FieldMetaInformation( axes, F.shape,
             group.attrs['gridSpacing'], group.attrs['gridGlobalOffset'],
             group.attrs['gridUnitSI'], dset.attrs['position'],
-            time, iteration )
+            time, iteration, component_attrs=dict(dset.attrs),
+            field_attrs=dict(group.attrs) )
 
     # Close the file
     dfile.close()
@@ -217,7 +219,8 @@ def read_field_circ( filename, iteration, field, coord,
     info = FieldMetaInformation( coord_labels, N_pair,
         group.attrs['gridSpacing'], group.attrs['gridGlobalOffset'],
         group.attrs['gridUnitSI'], dset.attrs['position'], time,
-        iteration, thetaMode=True )
+        iteration, thetaMode=True, component_attrs=dict(dset.attrs),
+        field_attrs=dict(group.attrs) )
 
     # Convert to a 3D Cartesian array if theta is None
     if theta is None:

--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/field_reader.py
@@ -78,6 +78,9 @@ def read_field_cartesian( series, iteration, field_name, component_name,
     grid_unit_SI = field.grid_unit_SI
     grid_position = component.position
     time = (it.time + field.time_offset) * it.time_unit_SI
+    
+    field_attrs = {a: field.get_attribute(a) for a in field.attributes}
+    component_attrs = {a: component.get_attribute(a) for a in component.attributes} 
 
     # Slice selection
     #   TODO put in general utilities
@@ -112,14 +115,16 @@ def read_field_cartesian( series, iteration, field_name, component_name,
         F = get_data( series, component, list_i_cell, list_slicing_index )
         info = FieldMetaInformation( axes, shape, grid_spacing, global_offset,
                 grid_unit_SI, grid_position,
-                time, iteration )
+                time, iteration, field_attrs=field_attrs,
+                component_attrs=component_attrs )
     else:
         F = get_data( series, component )
         axes = { i: axis_labels[i] for i in range(len(axis_labels)) }
         info = FieldMetaInformation( axes, F.shape,
             grid_spacing, global_offset,
             grid_unit_SI, grid_position,
-            time, iteration )
+            time, iteration, field_attrs=field_attrs,
+            component_attrs=component_attrs )
 
     return F, info
 
@@ -189,6 +194,9 @@ def read_field_circ( series, iteration, field_name, component_name,
         component = next(field.items())[1]
     else:
         component = field[component_name]
+    
+    field_attrs = {a: field.get_attribute(a) for a in field.attributes}
+    component_attrs = {a: component.get_attribute(a) for a in component.attributes} 
 
     # Extract the metainformation
     #   FIXME here and in h5py reader, we need to invert the order on 'F' for
@@ -211,7 +219,9 @@ def read_field_circ( series, iteration, field_name, component_name,
     # Nm, Nr, Nz = component.shape
     info = FieldMetaInformation( coord_labels, N_pair,
         field.grid_spacing, field.grid_global_offset,
-        field.grid_unit_SI, component.position, time, iteration, thetaMode=True )
+        field.grid_unit_SI, component.position, time, iteration,
+        thetaMode=True, field_attrs=field_attrs,
+        component_attrs=component_attrs )
 
     # Convert to a 3D Cartesian array if theta is None
     if theta is None:

--- a/openpmd_viewer/openpmd_timeseries/field_metainfo.py
+++ b/openpmd_viewer/openpmd_timeseries/field_metainfo.py
@@ -39,7 +39,7 @@ class FieldMetaInformation(object):
         the values in `axes`. For instance, if `axes` is {0: 'x', 1: 'y'},
         then these variables will be called dx and dy.
 
-     - x, z: 1darrays of double
+    - x, z: 1darrays of double
         The position of all the gridpoints, along each axis
         Notice that the name of these variables change according to
         the values in `axes`. For instance, if `axes` is {0: 'x', 1: 'y'},
@@ -69,6 +69,12 @@ class FieldMetaInformation(object):
         It allows the user to get the simulation time when calling the
         get_particle method for a given iteration and vice versa.
         Either `t` or `iteration` should be given.
+
+    - field_attrs: dict
+        All the attributes of the field record in the openPMD file.
+
+    - component_attrs: dict
+        All the attributes of the field component record in the openPMD file.
 
     """
 

--- a/openpmd_viewer/openpmd_timeseries/field_metainfo.py
+++ b/openpmd_viewer/openpmd_timeseries/field_metainfo.py
@@ -73,7 +73,8 @@ class FieldMetaInformation(object):
     """
 
     def __init__(self, axes, shape, grid_spacing,
-                 global_offset, grid_unitSI, position, t, iteration, thetaMode=False):
+                 global_offset, grid_unitSI, position, t, iteration,
+                 thetaMode=False, field_attrs=None, component_attrs=None):
         """
         Create a FieldMetaInformation object
 
@@ -105,6 +106,8 @@ class FieldMetaInformation(object):
         setattr(self, 'time', t)
         setattr(self, 'iteration', iteration)
 
+        self.field_attrs = field_attrs
+        self.component_attrs = component_attrs
         self._generate_imshow_extent()
 
 


### PR DESCRIPTION
This PR proposes adding two new optional attributes to the `FieldMetaInformation` class. The new attributes, called `component_attrs` and `field_attrs` are dictionaries that contain all of the `openPMD` attributes of the field and its component. Until now, the `FieldMetaInformation` only extracts and stores a subset of this information, so if a field record contains attributes that are not explicitly read by the viewer, they cannot be accessed by the user.