### PR TITLE
fix get_data for weighting in momentum reader

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/particle_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/particle_reader.py
@@ -80,7 +80,7 @@ def read_species_data(series, iteration, species_name, component_name,
         weighting_power = record.get_attribute('weightingPower')
         if (macro_weighted == 1) and (weighting_power != 0):
             w_component = next(species['weighting'].items())[1]
-            w = get_data( w_component )
+            w = get_data( series, w_component )
             data *= w ** (-weighting_power)
 
     # - Return positions, with an offset


### PR DESCRIPTION
In case of the ED-PIC extension, momentum values need to take into account the weighting. This failed for ADIOS/openPMD-api data - see issue #391. 
The reason for that was a missing argument in `getData( )`. This pull request fixes this issue.  

cc'ing @ax3l @cbontoiu 