### PR TITLE
use `%matplotlib widget` by default

### DIFF
--- a/openpmd_viewer/notebook_starter/Template_notebook.ipynb
+++ b/openpmd_viewer/notebook_starter/Template_notebook.ipynb
@@ -16,9 +16,8 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "# or `%matplotlib inline` for non-interactive plots\n",
-    "# or `%matplotlib widget` when using JupyterLab (github.com/matplotlib/jupyter-matplotlib)\n",
     "import matplotlib.pyplot as plt\n",
     "from openpmd_viewer import OpenPMDTimeSeries"
    ]


### PR DESCRIPTION
This is necessary even with Jupyter Notebook, not just Jupyterlab. See comment: https://github.com/openPMD/openPMD-api/issues/1572#issuecomment-1862616267.

The matplotlib documentation suggests this rendering backend will work in all modern versions of Jupyter Notebook and Jupyterlab: https://matplotlib.org/stable/users/explain/figure/interactive.html#jupyter-notebooks-jupyterlab.

Fixes https://github.com/openPMD/openPMD-api/issues/1572.