### PR TITLE
[WIP] Fill Invalid Regions w/ Zero

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/utilities.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/utilities.py
@@ -59,15 +59,14 @@ def get_data(series, record_component, i_slice=None, pos_slice=None,
     # ADIOS2: Actual chunks, all other: one chunk
     chunks = record_component.available_chunks()
 
-    # mask invalid regions with NaN: fill value
-    # note: NaN is only defined for floating point types
-    NaN_value = np.nan if np.issubdtype(record_component.dtype, np.floating) or np.issubdtype(record_component.dtype, np.complexfloating) else 0
+    # mask invalid regions with 0: fill value
+    fill_value = 0
 
     # read whole data set
     if pos_slice is None:
-        # mask invalid regions with NaN
+        # mask invalid regions with zero
         #   note: full_like triggers a full read, thus we avoid it #340
-        data = np.full(record_component.shape, NaN_value, record_component.dtype)
+        data = np.full(record_component.shape, fill_value, record_component.dtype)
 
         for chunk in chunks:
             chunk_slice = chunk_to_slice(chunk)
@@ -94,8 +93,8 @@ def get_data(series, record_component, i_slice=None, pos_slice=None,
         for dir_index in pos_slice_sorted:  # remove indices in list
             del slice_shape[dir_index]
 
-        # mask invalid regions with NaN
-        data = np.full(slice_shape, NaN_value, dtype=record_component.dtype)
+        # mask invalid regions with zero
+        data = np.full(slice_shape, fill_value, dtype=record_component.dtype)
 
         # build requested ND slice with respect to full data
         s = []


### PR DESCRIPTION
Filling unwritten/invalid regions, e.g., access outside of written ADIOS blocks, with not-a-number (NaN) created some confusion: https://github.com/ECP-WarpX/WarpX/issues/4775

Counter-point to this PR:
Technically, data in this region is literally not-a-number (yet). Matplotlib gracefully ignores NaNs for plotting, and can be configured to mask one way or the other with color. Padding with zeros is ambiguous: maybe data was not written, maybe data was written and truly zero.

We now always fill with zeros, hoping that "why is a region empty" ("because it was not written") does not create another kind of confusion.

Side note: resizing during write of BTD is non-trivial (as in: not supported by HDF5 and ADIOS), because we need to resize from the "lower index end". HDF5 and ADIOS only support resizing the upper index bound.

X-ref: #334 #340