### PR TITLE
[WIP] Overload the intersection and union operators for `ParticleTracker`

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -28,11 +28,12 @@ jobs:
           conda install --yes cython numpy scipy h5py openpmd-api matplotlib jupyter pytest pyflakes python=${{ matrix.python-version }} python-wget
         else
           conda install --yes cython numpy scipy h5py matplotlib jupyter pytest pyflakes python=${{ matrix.python-version }} python-wget
-        fi
+        fi;
+        python setup.py install
 
     - shell: bash -eo pipefail  -l {0}
       name: pyflakes
       run: python -m pyflakes openpmd_viewer
     - shell: bash -eo pipefail -l {0}
       name: Test
-      run: python setup.py test
+      run: python -m pytest tests

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,6 +15,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
-        python -m pip install cython numpy scipy h5py openpmd-api matplotlib jupyter pytest pyflakes wget
+        python -m pip install cython numpy scipy h5py openpmd-api matplotlib jupyter pytest pyflakes wget;
+        python setup.py install
     - name: Test
-      run: python setup.py test
+      run: python -m pytest tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ git pull git@github.com:openPMD/openPMD-viewer.git dev
   ```
   python -m pip wheel .
   python -m pip install *whl matplotlib jupyter
-  python setup.py test
+  python -m pytest tests
   ```
   (Be patient: the `test_tutorials.py` can take approx. 20 seconds if
   you already downloaded the example openPMD files that are required

--- a/openpmd_viewer/openpmd_timeseries/particle_tracker.py
+++ b/openpmd_viewer/openpmd_timeseries/particle_tracker.py
@@ -39,7 +39,7 @@ class ParticleTracker( object ):
     to be stored in the openPMD files.
     """
 
-    def __init__(self, ts, species=None, t=None,
+    def __init__(self, ts=None, species=None, t=None,
                 iteration=None, select=None, preserve_particle_index=False):
         """
         Initialize an instance of `ParticleTracker`: select particles at
@@ -69,8 +69,9 @@ class ParticleTracker( object ):
             'x' : [-4., 10.]  (Particles having x between -4 and 10)
             'ux' : [-0.1, 0.1] (Particles having ux between -0.1 and 0.1 mc)
             'uz' : [5., None]  (Particles with uz above 5 mc).
-            Can also be a 1d array of interegers corresponding to the
-            selected particles `id`
+            Can also be a 1d array of integers corresponding to the
+            selected particles `id`. In this case, the arguments `ts`, `t`
+            and `iteration` do not need to be passed.
 
         preserve_particle_index: bool, optional
             When retrieving particles at a several iterations,
@@ -105,6 +106,37 @@ class ParticleTracker( object ):
         self.species = species
         self.preserve_particle_index = preserve_particle_index
 
+    def __and__(self, other):
+        """
+        Define the intersection of two ParticleTracker instances.
+
+        This selects the particles that are present in both instances.
+        """
+        # Check that both instances are consistent
+        assert self.species == other.species
+        assert self.preserve_particle_index == other.preserve_particle_index
+
+        # Find the intersection of the selected particles
+        pid = np.intersect1d( self.selected_pid, other.selected_pid )
+        pt = ParticleTracker( species=self.species, select=pid,
+                             preserve_particle_index=self.preserve_particle_index )
+        return pt
+
+    def __or__(self, other):
+        """
+        Define the union of two ParticleTracker instances.
+
+        This selects the particles that are present in at least one of the instances.
+        """
+        # Check that both instances are consistent
+        assert self.species == other.species
+        assert self.preserve_particle_index == other.preserve_particle_index
+
+        # Find the union of the selected particles
+        pid = np.union1d( self.selected_pid, other.selected_pid )
+        pt = ParticleTracker( species=self.species, select=pid,
+                             preserve_particle_index=self.preserve_particle_index )
+        return pt
 
     def extract_tracked_particles( self, iteration, data_reader, data_list,
                                     species, extensions ):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
-import sys
 from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
 
 # Get the long description
 with open('./README.md') as f:
@@ -13,14 +11,6 @@ with open('./requirements.txt') as f:
 # This defines the variable __version__
 with open('./openpmd_viewer/__version__.py') as f:
     exec( f.read() )
-
-# Define a custom class to run the py.test with `python setup.py test`
-class PyTest(TestCommand):
-
-    def run_tests(self):
-        import pytest
-        errcode = pytest.main([])
-        sys.exit(errcode)
 
 # Main setup command
 setup(name='openPMD-viewer',
@@ -35,7 +25,6 @@ setup(name='openPMD-viewer',
       packages=find_packages('.'),
       package_data={'openpmd_viewer': ['notebook_starter/*.ipynb']},
       scripts=['openpmd_viewer/notebook_starter/openPMD_notebook'],
-      tests_require=['pytest', 'jupyter'],
       install_requires=install_requires,
       extras_require = {
         'all': ["ipympl", "ipywidgets", "matplotlib", "numba", "openpmd-api", "wget"],
@@ -45,7 +34,6 @@ setup(name='openPMD-viewer',
         'numba': ["numba"],
         'openpmd-api': ["openpmd-api"]
         },
-      cmdclass={'test': PyTest},
       platforms='any',
       python_requires='>=3.8',
       classifiers=[

--- a/tests/test_tutorials.py
+++ b/tests/test_tutorials.py
@@ -8,7 +8,7 @@ This file is meant to be run from the root directory of openPMD-viewer,
 by any of the following commands
 $ python tests/test_tutorials.py
 $ py.test
-$ python setup.py test
+$ python -m pytest tests
 
 Copyright 2015-2016, openPMD-viewer contributors
 Authors: Remi Lehe, Axel Huebl


### PR DESCRIPTION
This allows to do:
```python
pt_merged = pt1 || pt2   # Creates particle tracker that selects particles that are either in `pt1` and `pt2`
pt_intersect = p1 & pt2  # Creates particles tracker that are in both `pt1` and `pt2`
```

TODO: add tests and documentation