### PR TITLE
Fix h5py reader for Fortran order

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/field_reader.py
@@ -77,6 +77,11 @@ def read_field_cartesian( filename, iteration, field, coord, axis_labels,
     shape = list( get_shape( dset ) )
     grid_spacing = list( group.attrs['gridSpacing'] )
     global_offset = list( group.attrs['gridGlobalOffset'] )
+    position = list( dset.attrs['position'] )
+    if dset.attrs['dataOrder'].decode() == 'F':
+        grid_spacing = grid_spacing[::-1]
+        global_offset = global_offset[::-1]
+        position = position[::-1]
 
     # Current simulation time
     time = (it.attrs['time'] + group.attrs['timeOffset']) * it.attrs['timeUnitSI']
@@ -112,15 +117,15 @@ def read_field_cartesian( filename, iteration, field, coord, axis_labels,
         # Extract data
         F = get_data( dset, list_i_cell, list_slicing_index )
         info = FieldMetaInformation( axes, shape, grid_spacing, global_offset,
-                group.attrs['gridUnitSI'], dset.attrs['position'],
+                group.attrs['gridUnitSI'], position,
                 time, iteration, component_attrs=dict(dset.attrs),
                 field_attrs=dict(group.attrs) )
     else:
         F = get_data( dset )
         axes = { i: axis_labels[i] for i in range(len(axis_labels)) }
         info = FieldMetaInformation( axes, F.shape,
-            group.attrs['gridSpacing'], group.attrs['gridGlobalOffset'],
-            group.attrs['gridUnitSI'], dset.attrs['position'],
+            grid_spacing, global_offset,
+            group.attrs['gridUnitSI'], position,
             time, iteration, component_attrs=dict(dset.attrs),
             field_attrs=dict(group.attrs) )
 
@@ -200,7 +205,7 @@ def read_field_circ( filename, iteration, field, coord,
 
     # Current simulation time
     time = (it.attrs['time'] + group.attrs['timeOffset']) * it.attrs['timeUnitSI']
-    
+
     # Extract the metainformation
     coord_labels = {ii: coord.decode() for (ii,coord) in
                                 enumerate(group.attrs['axisLabels'])}

--- a/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/field_reader.py
@@ -77,11 +77,11 @@ def read_field_cartesian( filename, iteration, field, coord, axis_labels,
     shape = list( get_shape( dset ) )
     grid_spacing = list( group.attrs['gridSpacing'] )
     global_offset = list( group.attrs['gridGlobalOffset'] )
-    position = list( dset.attrs['position'] )
+    grid_position = list( dset.attrs['position'] )
     if group.attrs['dataOrder'].decode() == 'F':
         grid_spacing = grid_spacing[::-1]
         global_offset = global_offset[::-1]
-        position = position[::-1]
+        grid_position = grid_position[::-1]
 
     # Current simulation time
     time = (it.attrs['time'] + group.attrs['timeOffset']) * it.attrs['timeUnitSI']
@@ -117,7 +117,7 @@ def read_field_cartesian( filename, iteration, field, coord, axis_labels,
         # Extract data
         F = get_data( dset, list_i_cell, list_slicing_index )
         info = FieldMetaInformation( axes, shape, grid_spacing, global_offset,
-                group.attrs['gridUnitSI'], position,
+                group.attrs['gridUnitSI'], grid_position,
                 time, iteration, component_attrs=dict(dset.attrs),
                 field_attrs=dict(group.attrs) )
     else:
@@ -125,7 +125,7 @@ def read_field_cartesian( filename, iteration, field, coord, axis_labels,
         axes = { i: axis_labels[i] for i in range(len(axis_labels)) }
         info = FieldMetaInformation( axes, F.shape,
             grid_spacing, global_offset,
-            group.attrs['gridUnitSI'], position,
+            group.attrs['gridUnitSI'], grid_position,
             time, iteration, component_attrs=dict(dset.attrs),
             field_attrs=dict(group.attrs) )
 

--- a/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/h5py_reader/field_reader.py
@@ -78,7 +78,7 @@ def read_field_cartesian( filename, iteration, field, coord, axis_labels,
     grid_spacing = list( group.attrs['gridSpacing'] )
     global_offset = list( group.attrs['gridGlobalOffset'] )
     position = list( dset.attrs['position'] )
-    if dset.attrs['dataOrder'].decode() == 'F':
+    if group.attrs['dataOrder'].decode() == 'F':
         grid_spacing = grid_spacing[::-1]
         global_offset = global_offset[::-1]
         position = position[::-1]

--- a/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/field_reader.py
+++ b/openpmd_viewer/openpmd_timeseries/data_reader/io_reader/field_reader.py
@@ -78,9 +78,14 @@ def read_field_cartesian( series, iteration, field_name, component_name,
     grid_unit_SI = field.grid_unit_SI
     grid_position = component.position
     time = (it.time + field.time_offset) * it.time_unit_SI
-    
+
+    if field.get_attribute('dataOrder') == 'F':
+        grid_spacing = grid_spacing[::-1]
+        global_offset = global_offset[::-1]
+        grid_position = grid_position[::-1]
+
     field_attrs = {a: field.get_attribute(a) for a in field.attributes}
-    component_attrs = {a: component.get_attribute(a) for a in component.attributes} 
+    component_attrs = {a: component.get_attribute(a) for a in component.attributes}
 
     # Slice selection
     #   TODO put in general utilities
@@ -194,9 +199,9 @@ def read_field_circ( series, iteration, field_name, component_name,
         component = next(field.items())[1]
     else:
         component = field[component_name]
-    
+
     field_attrs = {a: field.get_attribute(a) for a in field.attributes}
-    component_attrs = {a: component.get_attribute(a) for a in component.attributes} 
+    component_attrs = {a: component.get_attribute(a) for a in component.attributes}
 
     # Extract the metainformation
     #   FIXME here and in h5py reader, we need to invert the order on 'F' for


### PR DESCRIPTION
The axes coordinates were not being read in the right order, for Fortran order data.

This PR fixes the issues.

Many thanks for @tsung1029 for pointing out this issue.