### PR TITLE
Fix figure display, when using %matplotlib widget

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/interactive.py
+++ b/openpmd_viewer/openpmd_timeseries/interactive.py
@@ -528,7 +528,7 @@ class InteractiveViewer(object):
             display(container_ptcl)
 
         # When using %matplotlib widget, display the figures at the end
-        if 'ipympl' in matplotlib.get_backend():
+        if matplotlib.get_backend() in ['ipympl', 'widget']:
             # Disable interactive mode
             # This prevents the notebook from showing the figure
             # when calling `plt.figure` (unreliable with `%matplotlib widget`)


### PR DESCRIPTION
In general, using `%matplotlib widget` or `%matplotlib ipympl` should be almost equivalent (see https://github.com/matplotlib/ipympl/issues/529). However, when using `openPMD-viewer`, the slider works fine when doing `%matplotlib ipympl`, but does not when doing `%matplotlib widget` (i.e. the figures are not displayed, when doing `%matplotlib widget).

This PR fixes the issue.