### PR TITLE
[WIP] Have openPMD-viewer slider work in Google Colab

### DIFF
--- a/openpmd_viewer/openpmd_timeseries/interactive.py
+++ b/openpmd_viewer/openpmd_timeseries/interactive.py
@@ -422,7 +422,7 @@ class InteractiveViewer(object):
             accord1.set_title(1, 'Slice selection')
             accord1.set_title(2, 'Plotting options')
             # Complete field container
-            container_fld = widgets.VBox( children=[accord1, widgets.HBox(
+            container_fld = widgets.VBox( children=[container_fields, widgets.HBox(
                 children=[fld_refresh_toggle, fld_refresh_button])])
             set_widget_dimensions( container_fld, width=370 )
 
@@ -512,7 +512,7 @@ class InteractiveViewer(object):
             accord2.set_title(1, 'Particle selection')
             accord2.set_title(2, 'Plotting options')
             # Complete particle container
-            container_ptcl = widgets.VBox( children=[accord2, widgets.HBox(
+            container_ptcl = widgets.VBox( children=[container_ptcl_quantities, widgets.HBox(
                 children=[ptcl_refresh_toggle, ptcl_refresh_button])])
             set_widget_dimensions( container_ptcl, width=370 )
 

--- a/openpmd_viewer/openpmd_timeseries/interactive.py
+++ b/openpmd_viewer/openpmd_timeseries/interactive.py
@@ -528,7 +528,7 @@ class InteractiveViewer(object):
             display(container_ptcl)
 
         # When using %matplotlib widget, display the figures at the end
-        if matplotlib.get_backend() in ['ipympl', 'widget']:
+        if matplotlib.get_backend() in ['ipympl', 'widget', 'module://ipympl.backend_nbagg']:
             # Disable interactive mode
             # This prevents the notebook from showing the figure
             # when calling `plt.figure` (unreliable with `%matplotlib widget`)


### PR DESCRIPTION
This makes a few changes to have `openPMD-viewer` work in Google Colab.

- When using `%matplotlib widget`, Google Colab renames the `widget` backend as `'module://ipympl.backend_nbagg'`
- The `Accordion` widget is not working (see https://github.com/googlecolab/colabtools/issues/3571) ; thus this avoids displaying the accordion

Note that, in order to setup the environment in Google Colab, I had to use the following code in the first two cells:
```
# Install required packages
!pip install git+https://github.com/openPMD/openPMD-viewer@enable_colab --quiet
!pip install ipympl --quiet
# Restart notebook so that the new packages are available
# This will raise a message saying "Your session crashed for an unknown reason", but simply ignore it
get_ipython().kernel.do_shutdown(restart=True)
```
```
# Enable interactive widgets in Colab
from google.colab import output
output.enable_custom_widget_manager()
%matplotlib widget
```