### PR TITLE
Add the openpmd_notebook command for jupyter lab

### DIFF
--- a/openpmd_viewer/notebook_starter/openPMD_notebook
+++ b/openpmd_viewer/notebook_starter/openPMD_notebook
@@ -21,4 +21,4 @@ with open('./openPMD-visualization.ipynb', 'w') as notebook_file:
     notebook_file.write( notebook_text.decode() )
 
 # Launch the corresponding notebook
-os.system('jupyter notebook openPMD-visualization.ipynb')
+os.system('jupyter-lab openPMD-visualization.ipynb')


### PR DESCRIPTION
The command `openpmd_notebook` does not work anymore on recent environment where only Jupyterlab is installed.